### PR TITLE
 fix(nimbleHelper): proper versions sorting

### DIFF
--- a/packages/MiNiM.json
+++ b/packages/MiNiM.json
@@ -4,86 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "617ef6e735550975bc331fa0af66457f6e726b3b",
-          "date": "2017-07-21T22:29:37+02:00",
-          "sha256": "1dl4d7saccx2f2pzc5v9fd3r66zdmkrajhx2qyzlhwhjdak8qbsm",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.1",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "709d64c116fe69c0d219fa969d73c75b63fc42ee",
-          "date": "2017-07-09T12:27:48+02:00",
-          "sha256": "0yvndccvij70947bclmxqirvajy5bvvlil6rafx2959fmp9yhs4b",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "5e09dd237d10d60108b7bbc1599d74a30d7af2bf",
-          "date": "2017-07-08T16:12:19+02:00",
-          "sha256": "0gavhi8fm3brr1xs855vhgqwl4lnlgck3y6gpac5wgvvzpimzqxl",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "243bb434a1415c09ccb53a7fd94388140eb3bcef",
-          "date": "2017-06-04T20:30:39+02:00",
-          "sha256": "1fgpj9rg43shsk11b9c71riiw3p9vxwcm10lr3b5fllns4qgzyw4",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "8dc873a6adb297076184b979dbb1427a81476c07",
-          "date": "2017-04-15T11:25:02+02:00",
-          "sha256": "0wv4gr2plll8kb4lbbyykgvr8hh3xdfkk6xc7jhlw7s6dd3plfn7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "68243bde5c29c633eef09420ec8ee0d018b48f06",
-          "date": "2017-03-25T14:21:26+01:00",
-          "sha256": "18rbnsw850vya8lc89g2ybmjm4wmqvmlbpymjy1q4qvfl71yihxl",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "ca1138ad77c32cfe86cd0d137b0682b81c65f41e",
-          "date": "2017-03-05T19:35:49+01:00",
-          "sha256": "1g658vd5v67rlbam7yapmsinj3z4d9f4nssm57qha5fhh6q8v11p",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "68fadcf5ed5a5c7c6d0300fc3c3af64d26a7f094",
-          "date": "2016-11-12T13:05:19+01:00",
-          "sha256": "1rnlplja39hpd66wswmrb63bpajlg9z2ifcjlr5ynslz6rg2iwm4",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.24.0",
         "value": {
           "url": "https://github.com/h3rald/minim",
@@ -172,26 +92,6 @@
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.2.1",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "2d6dea7f5b669381035f723ddfc9b5c77c362d2c",
-          "date": "2016-10-31T16:09:48+01:00",
-          "sha256": "0ni8h9p9jkdnvjvppz77581w90naylcidz4dlnrs8kyi0gc39fgn",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/h3rald/minim",
-          "rev": "a0efcd6b54e03b142fdf0db7c69e11082dc1b95b",
-          "date": "2016-10-30T19:10:14+01:00",
-          "sha256": "19lxkzv57ksffyxfx2p901llfijww3sz98v73nn3riav5awzmqw8",
-          "fetchSubmodules": false
         }
       },
       {
@@ -371,6 +271,106 @@
           "rev": "0ca3b4d70fd5fc4253f2346264b95ff7eaa19215",
           "date": "2017-07-30T19:20:48+02:00",
           "sha256": "1gn2gawhyz2psr1jx323skg9wl0h5hf5vax8k6zqsrqx012ahb6q",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "617ef6e735550975bc331fa0af66457f6e726b3b",
+          "date": "2017-07-21T22:29:37+02:00",
+          "sha256": "1dl4d7saccx2f2pzc5v9fd3r66zdmkrajhx2qyzlhwhjdak8qbsm",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.1",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "709d64c116fe69c0d219fa969d73c75b63fc42ee",
+          "date": "2017-07-09T12:27:48+02:00",
+          "sha256": "0yvndccvij70947bclmxqirvajy5bvvlil6rafx2959fmp9yhs4b",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "5e09dd237d10d60108b7bbc1599d74a30d7af2bf",
+          "date": "2017-07-08T16:12:19+02:00",
+          "sha256": "0gavhi8fm3brr1xs855vhgqwl4lnlgck3y6gpac5wgvvzpimzqxl",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "243bb434a1415c09ccb53a7fd94388140eb3bcef",
+          "date": "2017-06-04T20:30:39+02:00",
+          "sha256": "1fgpj9rg43shsk11b9c71riiw3p9vxwcm10lr3b5fllns4qgzyw4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "8dc873a6adb297076184b979dbb1427a81476c07",
+          "date": "2017-04-15T11:25:02+02:00",
+          "sha256": "0wv4gr2plll8kb4lbbyykgvr8hh3xdfkk6xc7jhlw7s6dd3plfn7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "68243bde5c29c633eef09420ec8ee0d018b48f06",
+          "date": "2017-03-25T14:21:26+01:00",
+          "sha256": "18rbnsw850vya8lc89g2ybmjm4wmqvmlbpymjy1q4qvfl71yihxl",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "ca1138ad77c32cfe86cd0d137b0682b81c65f41e",
+          "date": "2017-03-05T19:35:49+01:00",
+          "sha256": "1g658vd5v67rlbam7yapmsinj3z4d9f4nssm57qha5fhh6q8v11p",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "68fadcf5ed5a5c7c6d0300fc3c3af64d26a7f094",
+          "date": "2016-11-12T13:05:19+01:00",
+          "sha256": "1rnlplja39hpd66wswmrb63bpajlg9z2ifcjlr5ynslz6rg2iwm4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.1",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "2d6dea7f5b669381035f723ddfc9b5c77c362d2c",
+          "date": "2016-10-31T16:09:48+01:00",
+          "sha256": "0ni8h9p9jkdnvjvppz77581w90naylcidz4dlnrs8kyi0gc39fgn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/h3rald/minim",
+          "rev": "a0efcd6b54e03b142fdf0db7c69e11082dc1b95b",
+          "date": "2016-10-30T19:10:14+01:00",
+          "sha256": "19lxkzv57ksffyxfx2p901llfijww3sz98v73nn3riav5awzmqw8",
           "fetchSubmodules": false
         }
       },

--- a/packages/allographer.json
+++ b/packages/allographer.json
@@ -4,59 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/itsumura-h/nim-allographer",
-          "rev": "6a8e24f3e2db37b0c9e68c0c256506a4a28b03f4",
-          "date": "2020-04-05T05:26:26+09:00",
-          "path": "/nix/store/jf1rbjjm4a425v639cwz7zrc2azfqkq4-nim-allographer",
-          "sha256": "04rmpqav2pfrgdqpqmz8ngbrpr6mn6gnb450cy461i72lwdir8hn",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/itsumura-h/nim-allographer",
-          "rev": "a894a5c1b4acf39d2bc04e5855808dbc59fdbc2d",
-          "date": "2020-01-18T18:17:59+09:00",
-          "sha256": "1lmxsl5sis7l3civxq60k31j0fhya9hyjy6ad3yiwlwwkq9441cb",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.2",
-        "value": {
-          "url": "https://github.com/itsumura-h/nim-allographer",
-          "rev": "ca850e4aa3ebb93ae5a8b86c45b56f23f9a4837f",
-          "date": "2020-01-18T15:32:28+09:00",
-          "sha256": "1p262sm35sz4bg06p9gck6czxi5f13vaxd4vfdpkhpgva8znmjnd",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.1",
-        "value": {
-          "url": "https://github.com/itsumura-h/nim-allographer",
-          "rev": "875853419720e3e576bbd55b788a27c2cb08a0ed",
-          "date": "2020-01-13T23:43:38+09:00",
-          "sha256": "09zv75vmiaga7bsvsv1k803qybvypsdhqabk3ykl0q5v7bj3mahl",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/itsumura-h/nim-allographer",
-          "rev": "875853419720e3e576bbd55b788a27c2cb08a0ed",
-          "date": "2020-01-13T23:43:38+09:00",
-          "sha256": "09zv75vmiaga7bsvsv1k803qybvypsdhqabk3ykl0q5v7bj3mahl",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.13.6",
         "value": {
           "url": "https://github.com/itsumura-h/nim-allographer",
@@ -210,6 +157,59 @@
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/itsumura-h/nim-allographer",
+          "rev": "6a8e24f3e2db37b0c9e68c0c256506a4a28b03f4",
+          "date": "2020-04-05T05:26:26+09:00",
+          "path": "/nix/store/jf1rbjjm4a425v639cwz7zrc2azfqkq4-nim-allographer",
+          "sha256": "04rmpqav2pfrgdqpqmz8ngbrpr6mn6gnb450cy461i72lwdir8hn",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/itsumura-h/nim-allographer",
+          "rev": "a894a5c1b4acf39d2bc04e5855808dbc59fdbc2d",
+          "date": "2020-01-18T18:17:59+09:00",
+          "sha256": "1lmxsl5sis7l3civxq60k31j0fhya9hyjy6ad3yiwlwwkq9441cb",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.2",
+        "value": {
+          "url": "https://github.com/itsumura-h/nim-allographer",
+          "rev": "ca850e4aa3ebb93ae5a8b86c45b56f23f9a4837f",
+          "date": "2020-01-18T15:32:28+09:00",
+          "sha256": "1p262sm35sz4bg06p9gck6czxi5f13vaxd4vfdpkhpgva8znmjnd",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.1",
+        "value": {
+          "url": "https://github.com/itsumura-h/nim-allographer",
+          "rev": "875853419720e3e576bbd55b788a27c2cb08a0ed",
+          "date": "2020-01-13T23:43:38+09:00",
+          "sha256": "09zv75vmiaga7bsvsv1k803qybvypsdhqabk3ykl0q5v7bj3mahl",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/itsumura-h/nim-allographer",
+          "rev": "875853419720e3e576bbd55b788a27c2cb08a0ed",
+          "date": "2020-01-13T23:43:38+09:00",
+          "sha256": "09zv75vmiaga7bsvsv1k803qybvypsdhqabk3ykl0q5v7bj3mahl",
+          "fetchSubmodules": false
         }
       }
     ]

--- a/packages/anonimongo.json
+++ b/packages/anonimongo.json
@@ -4,6 +4,45 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.4.12",
+        "value": {
+          "url": "https://github.com/mashingan/anonimongo",
+          "rev": "0e0abe81bd185ddb1166743d573f4239e106e518",
+          "date": "2020-11-28T12:18:12+07:00",
+          "path": "/nix/store/s4606syfvpkxx9brl9rzf7zb02ikw99k-anonimongo",
+          "sha256": "1n2sx6xdfybj54k5hf60hi31yr955bbjcc46fqszqzimxc7f21wi",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.4.11",
+        "value": {
+          "url": "https://github.com/mashingan/anonimongo",
+          "rev": "23e6f836cd9c11a49eb86308cc014d0de0abd89c",
+          "date": "2020-10-03T16:31:31+07:00",
+          "path": "/nix/store/slk5y3hxic4x76rzq1axdnkvy21805fj-anonimongo",
+          "sha256": "0bm59v8vkyqlizm9p8f9g51l68mhnldwqvs62nxrnswzyk4ih4qi",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.4.10",
+        "value": {
+          "url": "https://github.com/mashingan/anonimongo",
+          "rev": "2562534080896086cbf5097551b7c72d36240ad2",
+          "date": "2020-09-27T00:51:41+07:00",
+          "path": "/nix/store/53lzckijw86jwy164dxpm1s3k99ml9qy-anonimongo",
+          "sha256": "1rsk811zmg23py42m55kwznf7b4f9csqdwg9dpivfavkm4cfkcpp",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.4.9",
         "value": {
           "url": "https://github.com/mashingan/anonimongo",
@@ -102,45 +141,6 @@
           "date": "2020-08-31T21:07:31+07:00",
           "path": "/nix/store/0whs9krwiw0jwxmwbvk2mhzz9765xgx6-anonimongo",
           "sha256": "0vja0g2mkbk6k5sv3b3yvmrgqqmgl2fv8bfdb62j4ddd01l1g1hq",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.4.12",
-        "value": {
-          "url": "https://github.com/mashingan/anonimongo",
-          "rev": "0e0abe81bd185ddb1166743d573f4239e106e518",
-          "date": "2020-11-28T12:18:12+07:00",
-          "path": "/nix/store/s4606syfvpkxx9brl9rzf7zb02ikw99k-anonimongo",
-          "sha256": "1n2sx6xdfybj54k5hf60hi31yr955bbjcc46fqszqzimxc7f21wi",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.4.11",
-        "value": {
-          "url": "https://github.com/mashingan/anonimongo",
-          "rev": "23e6f836cd9c11a49eb86308cc014d0de0abd89c",
-          "date": "2020-10-03T16:31:31+07:00",
-          "path": "/nix/store/slk5y3hxic4x76rzq1axdnkvy21805fj-anonimongo",
-          "sha256": "0bm59v8vkyqlizm9p8f9g51l68mhnldwqvs62nxrnswzyk4ih4qi",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.4.10",
-        "value": {
-          "url": "https://github.com/mashingan/anonimongo",
-          "rev": "2562534080896086cbf5097551b7c72d36240ad2",
-          "date": "2020-09-27T00:51:41+07:00",
-          "path": "/nix/store/53lzckijw86jwy164dxpm1s3k99ml9qy-anonimongo",
-          "sha256": "1rsk811zmg23py42m55kwznf7b4f9csqdwg9dpivfavkm4cfkcpp",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/packages/argparse.json
+++ b/packages/argparse.json
@@ -43,6 +43,26 @@
         }
       },
       {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/iffy/nim-argparse",
+          "rev": "a39ad187bb795132df1150f1276f0d92d1c7d48b",
+          "date": "2020-01-28T22:09:09-05:00",
+          "sha256": "12yi1brj4j80i3qir1ic0dfb7r4virfpxnq3z8vjnnahwx0f30ay",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/iffy/nim-argparse",
+          "rev": "fb1ae17785ce67bfadcb2fd461b5280e8c4bbcad",
+          "date": "2019-11-19T21:10:29-05:00",
+          "sha256": "1q8ww2di0hmgs7lyj1kpl3xdb0hcr4415mi9kpqbpz6v8sysc3wx",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.0",
         "value": {
           "url": "https://github.com/iffy/nim-argparse",
@@ -179,26 +199,6 @@
           "rev": "e7276feff7cf6b4f79487c1c9d52ce6a2c535934",
           "date": "2018-11-28T12:05:27-07:00",
           "sha256": "09ig27af4z19j7cipribjci03ailbrd3dchb4jv87sijxbnj7zgh",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/iffy/nim-argparse",
-          "rev": "a39ad187bb795132df1150f1276f0d92d1c7d48b",
-          "date": "2020-01-28T22:09:09-05:00",
-          "sha256": "12yi1brj4j80i3qir1ic0dfb7r4virfpxnq3z8vjnnahwx0f30ay",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/iffy/nim-argparse",
-          "rev": "fb1ae17785ce67bfadcb2fd461b5280e8c4bbcad",
-          "date": "2019-11-19T21:10:29-05:00",
-          "sha256": "1q8ww2di0hmgs7lyj1kpl3xdb0hcr4415mi9kpqbpz6v8sysc3wx",
           "fetchSubmodules": false
         }
       }

--- a/packages/bump.json
+++ b/packages/bump.json
@@ -4,76 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "1.8.9",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "e86c09ca152c480d3787acd0cab32be9a086e21b",
-          "date": "2019-11-14T11:12:40-05:00",
-          "sha256": "1gx9b2p70cq0c89qiqzx2yvg1z3zxdgrw5wmb8w2wkszqvjnz1nz",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.8",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "18f1d76788a0e14f85f11fda8a20a22067a42c65",
-          "date": "2019-11-09T20:07:44-05:00",
-          "sha256": "0v7wwmf81pv7qa4v4zpa2045bskz640rqxyys46zq25jyr8j7xnr",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.7",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "f15dccf2f3529eee7cf89bddcfb9f9acc076f005",
-          "date": "2019-11-08T21:57:59-05:00",
-          "sha256": "05xph0kfks64zf7jrwh59rbab4k95vhdmza10mynnp6x0rmkxp44",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.6",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "19bd5e5dea13c03429218c35748eba57eec4f3b5",
-          "date": "2019-11-05T12:35:41-05:00",
-          "sha256": "065g2b57qinp58vacs60ml3w87lz7ivp0alfw3rf2d4zxncxpgcn",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.5",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "96a2d6a9d5c1967535306264a6c12c665dbf2ae6",
-          "date": "2019-11-02T23:36:33-04:00",
-          "sha256": "0rbfgmz40a99ivx9wbkpbfnmds7cmxkr7h2vhjpnajzj4k9gjxfw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.4",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "28e402a113e26f16249c5ba35946a039297f5f16",
-          "date": "2019-11-02T23:12:21-04:00",
-          "sha256": "0ci5k7iclzn98pz8nwnsyil56367v2llgak1xxkk8qfffmjj7dal",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.3",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "eebbf7c8139f820ea8a8e45399d1864cd9fb3526",
-          "date": "2019-11-02T16:17:54-04:00",
-          "sha256": "13m0hrdhr7fz9wcgns2xri2bjqwyalml386ilsip2gim9sfnqxp6",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "1.8.24",
         "value": {
           "url": "https://github.com/disruptek/bump",
@@ -132,16 +62,6 @@
           "rev": "a0db6d8ee7a9eb304607755f454b037c25ae1c04",
           "date": "2020-03-08T13:18:59-04:00",
           "sha256": "0gl0aqq4r5hj6lpdg7pdd42q8k01ybarmw8zg1hhgxrllpc8pbxh",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.8.2",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "e1e83a9da19791d26b0c610ff2fdbfd8a6ed2c32",
-          "date": "2019-11-01T18:31:14-04:00",
-          "sha256": "0sqf8avm37mjxk0c0milypjy6lsvxa45kddv9z0ihcs1df3i16k4",
           "fetchSubmodules": false
         }
       },
@@ -246,6 +166,86 @@
         }
       },
       {
+        "name": "1.8.9",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "e86c09ca152c480d3787acd0cab32be9a086e21b",
+          "date": "2019-11-14T11:12:40-05:00",
+          "sha256": "1gx9b2p70cq0c89qiqzx2yvg1z3zxdgrw5wmb8w2wkszqvjnz1nz",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.8",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "18f1d76788a0e14f85f11fda8a20a22067a42c65",
+          "date": "2019-11-09T20:07:44-05:00",
+          "sha256": "0v7wwmf81pv7qa4v4zpa2045bskz640rqxyys46zq25jyr8j7xnr",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.7",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "f15dccf2f3529eee7cf89bddcfb9f9acc076f005",
+          "date": "2019-11-08T21:57:59-05:00",
+          "sha256": "05xph0kfks64zf7jrwh59rbab4k95vhdmza10mynnp6x0rmkxp44",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.6",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "19bd5e5dea13c03429218c35748eba57eec4f3b5",
+          "date": "2019-11-05T12:35:41-05:00",
+          "sha256": "065g2b57qinp58vacs60ml3w87lz7ivp0alfw3rf2d4zxncxpgcn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.5",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "96a2d6a9d5c1967535306264a6c12c665dbf2ae6",
+          "date": "2019-11-02T23:36:33-04:00",
+          "sha256": "0rbfgmz40a99ivx9wbkpbfnmds7cmxkr7h2vhjpnajzj4k9gjxfw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.4",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "28e402a113e26f16249c5ba35946a039297f5f16",
+          "date": "2019-11-02T23:12:21-04:00",
+          "sha256": "0ci5k7iclzn98pz8nwnsyil56367v2llgak1xxkk8qfffmjj7dal",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.3",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "eebbf7c8139f820ea8a8e45399d1864cd9fb3526",
+          "date": "2019-11-02T16:17:54-04:00",
+          "sha256": "13m0hrdhr7fz9wcgns2xri2bjqwyalml386ilsip2gim9sfnqxp6",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.8.2",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "e1e83a9da19791d26b0c610ff2fdbfd8a6ed2c32",
+          "date": "2019-11-01T18:31:14-04:00",
+          "sha256": "0sqf8avm37mjxk0c0milypjy6lsvxa45kddv9z0ihcs1df3i16k4",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "1.8.1",
         "value": {
           "url": "https://github.com/disruptek/bump",
@@ -262,6 +262,16 @@
           "rev": "8700c7b1c5244faeafe7ef960a1801861725f1e7",
           "date": "2019-10-28T16:32:24-04:00",
           "sha256": "0nhxy3vd37rg8jxbz1pvlfib4125nxs2k76kg3jyqwgqsh66vrz4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.7.10",
+        "value": {
+          "url": "https://github.com/disruptek/bump",
+          "rev": "190114e41b4eb859b1403f61aea472ffb70e6efb",
+          "date": "2019-10-26T00:03:29-04:00",
+          "sha256": "03hivq5p30kc3yc4cfjwxkmmc7q6xig3s06abj6823w5q5g9ngab",
           "fetchSubmodules": false
         }
       },
@@ -342,16 +352,6 @@
           "rev": "16d34c20923071f3d93fd051c4ba5414320dae53",
           "date": "2019-10-22T23:57:54-04:00",
           "sha256": "13qiyf8fwr594krw8jjf2cq8786mx202cwn5dznbk5x1hh4z63gr",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.7.10",
-        "value": {
-          "url": "https://github.com/disruptek/bump",
-          "rev": "190114e41b4eb859b1403f61aea472ffb70e6efb",
-          "date": "2019-10-26T00:03:29-04:00",
-          "sha256": "03hivq5p30kc3yc4cfjwxkmmc7q6xig3s06abj6823w5q5g9ngab",
           "fetchSubmodules": false
         }
       },

--- a/packages/chronicles.json
+++ b/packages/chronicles.json
@@ -4,6 +4,19 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/status-im/nim-chronicles",
+          "rev": "b60f70718f8039c5c86dfc2a4680d8c1e37cbce2",
+          "date": "2020-08-15T00:28:51+03:00",
+          "path": "/nix/store/i4chd1805ajlci4kqb9mvh8pyrcjzcnn-nim-chronicles",
+          "sha256": "0hm7jzrjdbdl8yqd3vvh2l16v5mxwpyxvgqvvz8m2bpa77yahwyy",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.9.2",
         "value": {
           "url": "https://github.com/status-im/nim-chronicles",
@@ -209,19 +222,6 @@
           "date": "2018-06-19T17:11:05+03:00",
           "sha256": "0hzplc0nmmrp3vrqn0342d5jzxizry8730z1np509f3vz42rrzkv",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/status-im/nim-chronicles",
-          "rev": "b60f70718f8039c5c86dfc2a4680d8c1e37cbce2",
-          "date": "2020-08-15T00:28:51+03:00",
-          "path": "/nix/store/i4chd1805ajlci4kqb9mvh8pyrcjzcnn-nim-chronicles",
-          "sha256": "0hm7jzrjdbdl8yqd3vvh2l16v5mxwpyxvgqvvz8m2bpa77yahwyy",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       }
     ]

--- a/packages/cligen.json
+++ b/packages/cligen.json
@@ -108,26 +108,6 @@
         }
       },
       {
-        "name": "0.9.9",
-        "value": {
-          "url": "https://github.com/c-blake/cligen.git",
-          "rev": "4ed0e6bc4d39e71f75609b32be8b1f4c2a76c1ea",
-          "date": "2018-05-04T08:29:34-04:00",
-          "sha256": "0g1hc47ibv3q70iz4pjfp78xdvmkvb7amrxmx0acph9bzf49glb4",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.6",
-        "value": {
-          "url": "https://github.com/c-blake/cligen.git",
-          "rev": "2fc9a2558ad9c633469872d268205f06893d06d8",
-          "date": "2017-11-30T16:11:13-05:00",
-          "sha256": "0nvnfksjgwzq8s2y8nibqm1nzlbgdxdxn848n1f282wb6gk64fcy",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.9.47",
         "value": {
           "url": "https://github.com/c-blake/cligen.git",
@@ -216,16 +196,6 @@
           "rev": "e6243489021f679e3a24325db0855c2aaacc96e2",
           "date": "2019-10-24T07:01:23-04:00",
           "sha256": "0ckdii26g4i5sgp132v1x0wgm8hr4sznsmhchz4p36kpdpibwm0v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.4",
-        "value": {
-          "url": "https://github.com/c-blake/cligen.git",
-          "rev": "63a981662ccba1a95dc15ddf8749f2ec045e205e",
-          "date": "2017-11-03T07:30:27-04:00",
-          "sha256": "1bknpxw6gx76fas8hh904pyfk8n0q51d1850250d6pra6bv35h3h",
           "fetchSubmodules": false
         }
       },
@@ -496,6 +466,36 @@
           "rev": "3da23df929dd642180325d735e7d4954260202d2",
           "date": "2018-05-09T13:15:25-04:00",
           "sha256": "00k2h13mlw58ksbx0q3d51gjz39b6qgl4dd0y50ak15ilxs860jw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.9",
+        "value": {
+          "url": "https://github.com/c-blake/cligen.git",
+          "rev": "4ed0e6bc4d39e71f75609b32be8b1f4c2a76c1ea",
+          "date": "2018-05-04T08:29:34-04:00",
+          "sha256": "0g1hc47ibv3q70iz4pjfp78xdvmkvb7amrxmx0acph9bzf49glb4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.6",
+        "value": {
+          "url": "https://github.com/c-blake/cligen.git",
+          "rev": "2fc9a2558ad9c633469872d268205f06893d06d8",
+          "date": "2017-11-30T16:11:13-05:00",
+          "sha256": "0nvnfksjgwzq8s2y8nibqm1nzlbgdxdxn848n1f282wb6gk64fcy",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.4",
+        "value": {
+          "url": "https://github.com/c-blake/cligen.git",
+          "rev": "63a981662ccba1a95dc15ddf8749f2ec045e205e",
+          "date": "2017-11-03T07:30:27-04:00",
+          "sha256": "1bknpxw6gx76fas8hh904pyfk8n0q51d1850250d6pra6bv35h3h",
           "fetchSubmodules": false
         }
       }

--- a/packages/commandeer.json
+++ b/packages/commandeer.json
@@ -4,6 +4,86 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.12.3",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "d8f246703de3c17763a492c8f8ab53ffd8542a28",
+          "date": "2018-01-02T11:34:09-05:00",
+          "sha256": "058w6rmd57297h6ndv3kjlggqb4xzlmw4h2m7r4fr8ph5b3nqaby",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.12.1",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "0e9cee840845f8526631e28c93765d8de8523374",
+          "date": "2017-12-19T18:51:46-05:00",
+          "sha256": "1b0xyr6sb05lk2mkj3gv1inr093wmqrz5p1zi1cgsy4kkcy20ca6",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "6729d9b92e89fb0a51aac2e9cef94e1e95518d7e",
+          "date": "2017-10-15T13:10:18-04:00",
+          "sha256": "1kwcksad7jcdfdjfy41na3yl5b2gzmjkvy5nwv4wap3xcrgffxbg",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "6b4ea600559785b99b2d69b29ad9f14f6363957c",
+          "date": "2017-03-05T12:53:38-05:00",
+          "sha256": "18bhdhk6yhqll964l6z01rgh2bah9a91m52ly82mran3wh7fwz1g",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.5",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "e4c7e52e10825ee91afce37ef43200a0d141099f",
+          "date": "2016-08-20T16:25:04-04:00",
+          "sha256": "1zq9b461wmsk5j33giv959pd5bgxaarl7cxyaggycpgr2l5vkq5l",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.4",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "131c2a43deee0344ea12801af17f5a962d2de411",
+          "date": "2016-06-08T23:31:56-04:00",
+          "sha256": "1zcrny6pjxva61aqyj11byj10g9fyrdqjpndxnncrh6yjyiy1xl7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.3",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "4a3f1cd2f3a33d98c06c9535a9d6823ae3a33f24",
+          "date": "2016-02-14T18:28:19-05:00",
+          "sha256": "168zf0pnzpapscfkznrnr2midh097c08z27hwzz7hsj5j1ibapqx",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.2",
+        "value": {
+          "url": "https://github.com/fenekku/commandeer",
+          "rev": "3f532aed124230093a837ac16c239aada11bde84",
+          "date": "2016-02-14T18:07:53-05:00",
+          "sha256": "19n2h36xp5qky44x451g21b5hmha1biykhvjqb4ik7w8j28fv54a",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.1",
         "value": {
           "url": "https://github.com/fenekku/commandeer",
@@ -100,86 +180,6 @@
           "rev": "514437e27a2f442e7c433080da0ace99257d786f",
           "date": "2014-05-10T21:46:48-04:00",
           "sha256": "1py7qnn726j8ldc00mjdzmxw3g4jhh6jbapjp9fl98bk41qymmfa",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.3",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "d8f246703de3c17763a492c8f8ab53ffd8542a28",
-          "date": "2018-01-02T11:34:09-05:00",
-          "sha256": "058w6rmd57297h6ndv3kjlggqb4xzlmw4h2m7r4fr8ph5b3nqaby",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.1",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "0e9cee840845f8526631e28c93765d8de8523374",
-          "date": "2017-12-19T18:51:46-05:00",
-          "sha256": "1b0xyr6sb05lk2mkj3gv1inr093wmqrz5p1zi1cgsy4kkcy20ca6",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "6729d9b92e89fb0a51aac2e9cef94e1e95518d7e",
-          "date": "2017-10-15T13:10:18-04:00",
-          "sha256": "1kwcksad7jcdfdjfy41na3yl5b2gzmjkvy5nwv4wap3xcrgffxbg",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "6b4ea600559785b99b2d69b29ad9f14f6363957c",
-          "date": "2017-03-05T12:53:38-05:00",
-          "sha256": "18bhdhk6yhqll964l6z01rgh2bah9a91m52ly82mran3wh7fwz1g",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.5",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "e4c7e52e10825ee91afce37ef43200a0d141099f",
-          "date": "2016-08-20T16:25:04-04:00",
-          "sha256": "1zq9b461wmsk5j33giv959pd5bgxaarl7cxyaggycpgr2l5vkq5l",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.4",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "131c2a43deee0344ea12801af17f5a962d2de411",
-          "date": "2016-06-08T23:31:56-04:00",
-          "sha256": "1zcrny6pjxva61aqyj11byj10g9fyrdqjpndxnncrh6yjyiy1xl7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.3",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "4a3f1cd2f3a33d98c06c9535a9d6823ae3a33f24",
-          "date": "2016-02-14T18:28:19-05:00",
-          "sha256": "168zf0pnzpapscfkznrnr2midh097c08z27hwzz7hsj5j1ibapqx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.2",
-        "value": {
-          "url": "https://github.com/fenekku/commandeer",
-          "rev": "3f532aed124230093a837ac16c239aada11bde84",
-          "date": "2016-02-14T18:07:53-05:00",
-          "sha256": "19n2h36xp5qky44x451g21b5hmha1biykhvjqb4ik7w8j28fv54a",
           "fetchSubmodules": false
         }
       },

--- a/packages/compiler.json
+++ b/packages/compiler.json
@@ -95,6 +95,19 @@
         }
       },
       {
+        "name": "1.0.10",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "0ca09f64cf6ecf2050b58bc26ebc622f856b4dc2",
+          "date": "2020-10-26T14:25:28+01:00",
+          "path": "/nix/store/p5c80ck3pnyf2k9wcnjrp2jyji30v8z6-Nim",
+          "sha256": "17yl2263zq2w16gyi3302w4nvwdisl3lmkpsnmp2f5lsrh7jllf0",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "1.0.8",
         "value": {
           "url": "https://github.com/nim-lang/Nim.git",
@@ -138,75 +151,12 @@
         }
       },
       {
-        "name": "1.0.10",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "0ca09f64cf6ecf2050b58bc26ebc622f856b4dc2",
-          "date": "2020-10-26T14:25:28+01:00",
-          "path": "/nix/store/p5c80ck3pnyf2k9wcnjrp2jyji30v8z6-Nim",
-          "sha256": "17yl2263zq2w16gyi3302w4nvwdisl3lmkpsnmp2f5lsrh7jllf0",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "1.0.0",
         "value": {
           "url": "https://github.com/nim-lang/Nim.git",
           "rev": "f7a8fc46c0012033917582eb740dc0343c093e35",
           "date": "2019-09-23T19:06:55+02:00",
           "sha256": "1digc1a1ipbcfa9j1jsxpfwpai80fxx6mys5lljbbfn2ykln7xfi",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.6",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "98751caed47dbdd47642d7e9d181298b4edc8c30",
-          "date": "2014-10-19T20:50:14+02:00",
-          "sha256": "1b2wkmcghbfsad2fsfflpspzlj9drjbagdqx78jc4h3k27mps86a",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.4",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "687a1b7de4c006750274fb046a10f08d38c22f5a",
-          "date": "2014-04-21T10:10:28+02:00",
-          "sha256": "1wn6dhkqwbsf2g8sykxmck2c99msi424cbzzw76apb0mj52cklwp",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.2",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "220d35d9e19b0eae9e7cd1f1cac6e77e798dbc72",
-          "date": "2013-05-20T17:32:36+02:00",
-          "sha256": "1lq1qxwkm9g7wsf970axfx0bfpjqinbm8bgx63b2gww8zm1f2f6h",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "92b0d640180c02489061eada2cb585f05e61eebc",
-          "date": "2012-09-23T21:57:19+02:00",
-          "sha256": "0kp80bvzqp3x7lwg8m3qs6d9kq3jc8s35pvryshk3a3c3lxj3b06",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.14",
-        "value": {
-          "url": "https://github.com/nim-lang/Nim.git",
-          "rev": "32b4192b3f0771af11e9d850046e5f3dd42a9a5f",
-          "date": "2012-02-09T01:18:33+01:00",
-          "sha256": "0jsp0fh44bkkcvvi1bnxdlxmpp6cx528z201srs1c948qksqxpgh",
           "fetchSubmodules": false
         }
       },
@@ -397,6 +347,56 @@
           "rev": "92c873154a36d34ff8e18de6b2d1a0eb1b611860",
           "date": "2014-12-29T10:32:13+01:00",
           "sha256": "0q5xgbkvrqi6srs1j4ri5yy3aary7vc6sdgbiv0l8i0d7hcyjfna",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.6",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "98751caed47dbdd47642d7e9d181298b4edc8c30",
+          "date": "2014-10-19T20:50:14+02:00",
+          "sha256": "1b2wkmcghbfsad2fsfflpspzlj9drjbagdqx78jc4h3k27mps86a",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.4",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "687a1b7de4c006750274fb046a10f08d38c22f5a",
+          "date": "2014-04-21T10:10:28+02:00",
+          "sha256": "1wn6dhkqwbsf2g8sykxmck2c99msi424cbzzw76apb0mj52cklwp",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.2",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "220d35d9e19b0eae9e7cd1f1cac6e77e798dbc72",
+          "date": "2013-05-20T17:32:36+02:00",
+          "sha256": "1lq1qxwkm9g7wsf970axfx0bfpjqinbm8bgx63b2gww8zm1f2f6h",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "92b0d640180c02489061eada2cb585f05e61eebc",
+          "date": "2012-09-23T21:57:19+02:00",
+          "sha256": "0kp80bvzqp3x7lwg8m3qs6d9kq3jc8s35pvryshk3a3c3lxj3b06",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.14",
+        "value": {
+          "url": "https://github.com/nim-lang/Nim.git",
+          "rev": "32b4192b3f0771af11e9d850046e5f3dd42a9a5f",
+          "date": "2012-02-09T01:18:33+01:00",
+          "sha256": "0jsp0fh44bkkcvvi1bnxdlxmpp6cx528z201srs1c948qksqxpgh",
           "fetchSubmodules": false
         }
       }

--- a/packages/cucumber.json
+++ b/packages/cucumber.json
@@ -4,6 +4,26 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.0.11",
+        "value": {
+          "url": "https://github.com/shaunc/cucumber_nim",
+          "rev": "ced60f5dceef4c6da7b077997068a8c9bc5ad6db",
+          "date": "2016-12-27T03:27:01-05:00",
+          "sha256": "1z0pns9ynjbq3kp4z906dh5jgx0f0ndikhd4js5l8l4b5dk9z8x9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.0.10",
+        "value": {
+          "url": "https://github.com/shaunc/cucumber_nim",
+          "rev": "5cceeb04b1741b220d45984c8f3facad159fb4cd",
+          "date": "2016-12-27T02:16:08-05:00",
+          "sha256": "0bnxa23jf4y9rfjzrnp3fcnbmq5y9klqg8c2q8k57lsqndi3gh2j",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.0.9",
         "value": {
           "url": "https://github.com/shaunc/cucumber_nim",
@@ -70,26 +90,6 @@
           "rev": "63fc3fe940f34be51967d18bf924990e63da1990",
           "date": "2016-04-23T01:55:21-04:00",
           "sha256": "1hw1zqcfxw3zmz65karlpqcnldw8c45imxiw799nzcjva6pz5n5j",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.0.11",
-        "value": {
-          "url": "https://github.com/shaunc/cucumber_nim",
-          "rev": "ced60f5dceef4c6da7b077997068a8c9bc5ad6db",
-          "date": "2016-12-27T03:27:01-05:00",
-          "sha256": "1z0pns9ynjbq3kp4z906dh5jgx0f0ndikhd4js5l8l4b5dk9z8x9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.0.10",
-        "value": {
-          "url": "https://github.com/shaunc/cucumber_nim",
-          "rev": "5cceeb04b1741b220d45984c8f3facad159fb4cd",
-          "date": "2016-12-27T02:16:08-05:00",
-          "sha256": "0bnxa23jf4y9rfjzrnp3fcnbmq5y9klqg8c2q8k57lsqndi3gh2j",
           "fetchSubmodules": false
         }
       }

--- a/packages/euwren.json
+++ b/packages/euwren.json
@@ -4,106 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.1",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "52081f8eced7470e19a0a46e29fe6ffb8ae5cd10",
-          "date": "2019-12-14T21:49:48+01:00",
-          "sha256": "1vmz8f6grbn9rbva6ln572ya7vn4v6xvqch4y1gr8dclns7hfycp",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "7c882d78011db8bca48daceea115e0c82b58260c",
-          "date": "2019-12-11T22:10:54+01:00",
-          "sha256": "0l10aq1jwd57cgsla6l7rx8hr29x7ffbpzmqp39f91rndp9gcrap",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "d409c5a4dbd35406e705d56cd6cb95ab775e1ef1",
-          "date": "2019-12-11T19:12:14+01:00",
-          "sha256": "1lk243wl2dikjxknwn5kw20cz29gzjfxlr42l1xg8q4j32b92vih",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "9bbd15d5eeb2b4c47ea45225ca6d23ea9141a76b",
-          "date": "2019-12-09T17:56:04+01:00",
-          "sha256": "1q2n9crri13k19ynn5gxr0wagczds3dy4y7clv28s4bihf3yq49i",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "e0354cf442ef6bad9b0714b265f4544c0fc1393e",
-          "date": "2019-12-05T21:59:38+01:00",
-          "sha256": "0v6vyc42i92d19j0088fs6s2lyf385iy447zizszkhnqgh6idrym",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.1",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "f41c17061742aea8d8119066fd444b6c14d7c283",
-          "date": "2019-12-05T18:48:02+01:00",
-          "sha256": "1m61jch5i2y2gr5pqs29radai4i0ckhcy3cwy2m8gg06f89qxm8x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "8c016403f8981a96a2111f7d13a745a1db5c1fb3",
-          "date": "2019-12-04T22:06:25+01:00",
-          "sha256": "0sj8p77qhvxg6nmdjgkynzpmy6n8mxchk6cwifg96f7iq3jw7219",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "35754b9aee8a00ce19c0d8a06c0ad9d92c6d0fc2",
-          "date": "2019-12-04T18:06:38+01:00",
-          "sha256": "1ac2imb8bkz16x3bj1cf5qxfq18qf577xmg15r25hg8vibs20ws8",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "9ffe67e2bc7d57e983ddb45b06da9d24bbd2ecaf",
-          "date": "2019-12-02T21:17:18+01:00",
-          "sha256": "1mqcq0bl65vkf21hhvm3s2azsar3sg72vhjqfkx2nm5wl4zsgp62",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/liquid600pgm/euwren",
-          "rev": "cf1e62301dbe7fc156667bc75bf29b6e6b9bb234",
-          "date": "2019-11-17T17:22:32+01:00",
-          "sha256": "1qm7alfxng723hari306zy62diyjk8wwv88nlsrnv7npgs0jk4nl",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.13.3",
         "value": {
           "url": "https://github.com/liquid600pgm/euwren",
@@ -200,6 +100,106 @@
           "rev": "7a27426e68fd4839c8bbf94b088c66bdb8215cfb",
           "date": "2019-12-16T22:36:17+01:00",
           "sha256": "0gzvf1qccl54akvki5kgz5hhdrmjs2q2vay8vk5m3lprq3qwp1gs",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.1",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "52081f8eced7470e19a0a46e29fe6ffb8ae5cd10",
+          "date": "2019-12-14T21:49:48+01:00",
+          "sha256": "1vmz8f6grbn9rbva6ln572ya7vn4v6xvqch4y1gr8dclns7hfycp",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "7c882d78011db8bca48daceea115e0c82b58260c",
+          "date": "2019-12-11T22:10:54+01:00",
+          "sha256": "0l10aq1jwd57cgsla6l7rx8hr29x7ffbpzmqp39f91rndp9gcrap",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "d409c5a4dbd35406e705d56cd6cb95ab775e1ef1",
+          "date": "2019-12-11T19:12:14+01:00",
+          "sha256": "1lk243wl2dikjxknwn5kw20cz29gzjfxlr42l1xg8q4j32b92vih",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "9bbd15d5eeb2b4c47ea45225ca6d23ea9141a76b",
+          "date": "2019-12-09T17:56:04+01:00",
+          "sha256": "1q2n9crri13k19ynn5gxr0wagczds3dy4y7clv28s4bihf3yq49i",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "e0354cf442ef6bad9b0714b265f4544c0fc1393e",
+          "date": "2019-12-05T21:59:38+01:00",
+          "sha256": "0v6vyc42i92d19j0088fs6s2lyf385iy447zizszkhnqgh6idrym",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.1",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "f41c17061742aea8d8119066fd444b6c14d7c283",
+          "date": "2019-12-05T18:48:02+01:00",
+          "sha256": "1m61jch5i2y2gr5pqs29radai4i0ckhcy3cwy2m8gg06f89qxm8x",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "8c016403f8981a96a2111f7d13a745a1db5c1fb3",
+          "date": "2019-12-04T22:06:25+01:00",
+          "sha256": "0sj8p77qhvxg6nmdjgkynzpmy6n8mxchk6cwifg96f7iq3jw7219",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "35754b9aee8a00ce19c0d8a06c0ad9d92c6d0fc2",
+          "date": "2019-12-04T18:06:38+01:00",
+          "sha256": "1ac2imb8bkz16x3bj1cf5qxfq18qf577xmg15r25hg8vibs20ws8",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "9ffe67e2bc7d57e983ddb45b06da9d24bbd2ecaf",
+          "date": "2019-12-02T21:17:18+01:00",
+          "sha256": "1mqcq0bl65vkf21hhvm3s2azsar3sg72vhjqfkx2nm5wl4zsgp62",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/liquid600pgm/euwren",
+          "rev": "cf1e62301dbe7fc156667bc75bf29b6e6b9bb234",
+          "date": "2019-11-17T17:22:32+01:00",
+          "sha256": "1qm7alfxng723hari306zy62diyjk8wwv88nlsrnv7npgs0jk4nl",
           "fetchSubmodules": false
         }
       },

--- a/packages/faker.json
+++ b/packages/faker.json
@@ -14,6 +14,105 @@
         }
       },
       {
+        "name": "0.13.2",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "c6c61488159c445cf26562074463f719a1e1e406",
+          "date": "2020-07-18T17:59:25+00:00",
+          "path": "/nix/store/axl3id387nnscds6njinv6c74b4inhix-faker",
+          "sha256": "0yqzdcad6zmnv09af3pdxmpgr6q2jsx2614ffvfksjnzjak7h400",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.13.1",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "b86319ce36ccf53a8ad24de4a65b63df101f7582",
+          "date": "2020-07-18T17:52:12+00:00",
+          "path": "/nix/store/7rnfdkkc7ianqcifkdxmnj5y2n85ggbj-faker",
+          "sha256": "00v62mrvdw9zbfciykhds2511pl77nimqw47cvng24x4x1hgpmn9",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.13.0",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "240d5f71587d364acd110f3e984c0da42323f395",
+          "date": "2020-04-18T01:53:37+09:00",
+          "path": "/nix/store/0n5g3dkw16fwrhqsdkar6zabf97wpj7i-faker",
+          "sha256": "0n3ccfwg7lixk3ijbg66ziipzrj4wxxmjpd56nrgkp85y6zypndc",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.12.1",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "21648342e902e76d57e8fd6e1e62afacfe950d92",
+          "date": "2020-03-08T21:53:56+09:00",
+          "sha256": "1rawxvc7ifcr0sw7qaj4smvgsnn98370qsjqihndsl9g914cmhbg",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "a89300bcde2914be0f13c17c7a6441c96de3529d",
+          "date": "2020-03-08T19:58:02+09:00",
+          "sha256": "1qfwjpcapb05wa6hp8mln3nm64dkikpld27d24jwad0kg2prp4ds",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.2",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "b0edc03371a690808a7488e169f875d5c4c984b7",
+          "date": "2020-02-10T22:03:59+09:00",
+          "sha256": "1ixqb2q1ljcjkkwqfip21zzkngfsg5iba5lcr6yr7q3glapq56hk",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.1",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "b4554f78d2be8d41ee562ef9615a296bf48268a6",
+          "date": "2020-02-10T11:49:45+00:00",
+          "sha256": "0247y9qfxh3cfa4m5rzadgk4pp8l9yqj0zc66gizb1rbyg41kjr2",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "7f382f58572bca55c9304decf7280dc974557e89",
+          "date": "2020-02-10T06:54:36+00:00",
+          "sha256": "0bmpv3rjdqmjjq4pb8qp4fyn2di05j91vp8ag9vsxwb8d6rgl55c",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/jiro4989/faker",
+          "rev": "916feb1d3b262c9bf710ff17a4e7f798c2a070ec",
+          "date": "2020-02-10T03:04:27+00:00",
+          "sha256": "0ximkgycy7zzic398agsdvfmbf6w64axqlcp23ia1lpqhzhlms7m",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.0",
         "value": {
           "url": "https://github.com/jiro4989/faker",
@@ -150,105 +249,6 @@
           "rev": "4552748f94a3b12300653ce22526a9442760f127",
           "date": "2019-12-21T15:42:59+09:00",
           "sha256": "1jhi2x776r57m4rg3vakrvhj59khhabybhkav9vyw3jcncri1i0s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.13.2",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "c6c61488159c445cf26562074463f719a1e1e406",
-          "date": "2020-07-18T17:59:25+00:00",
-          "path": "/nix/store/axl3id387nnscds6njinv6c74b4inhix-faker",
-          "sha256": "0yqzdcad6zmnv09af3pdxmpgr6q2jsx2614ffvfksjnzjak7h400",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.13.1",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "b86319ce36ccf53a8ad24de4a65b63df101f7582",
-          "date": "2020-07-18T17:52:12+00:00",
-          "path": "/nix/store/7rnfdkkc7ianqcifkdxmnj5y2n85ggbj-faker",
-          "sha256": "00v62mrvdw9zbfciykhds2511pl77nimqw47cvng24x4x1hgpmn9",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.13.0",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "240d5f71587d364acd110f3e984c0da42323f395",
-          "date": "2020-04-18T01:53:37+09:00",
-          "path": "/nix/store/0n5g3dkw16fwrhqsdkar6zabf97wpj7i-faker",
-          "sha256": "0n3ccfwg7lixk3ijbg66ziipzrj4wxxmjpd56nrgkp85y6zypndc",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.12.1",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "21648342e902e76d57e8fd6e1e62afacfe950d92",
-          "date": "2020-03-08T21:53:56+09:00",
-          "sha256": "1rawxvc7ifcr0sw7qaj4smvgsnn98370qsjqihndsl9g914cmhbg",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "a89300bcde2914be0f13c17c7a6441c96de3529d",
-          "date": "2020-03-08T19:58:02+09:00",
-          "sha256": "1qfwjpcapb05wa6hp8mln3nm64dkikpld27d24jwad0kg2prp4ds",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.2",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "b0edc03371a690808a7488e169f875d5c4c984b7",
-          "date": "2020-02-10T22:03:59+09:00",
-          "sha256": "1ixqb2q1ljcjkkwqfip21zzkngfsg5iba5lcr6yr7q3glapq56hk",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.1",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "b4554f78d2be8d41ee562ef9615a296bf48268a6",
-          "date": "2020-02-10T11:49:45+00:00",
-          "sha256": "0247y9qfxh3cfa4m5rzadgk4pp8l9yqj0zc66gizb1rbyg41kjr2",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "7f382f58572bca55c9304decf7280dc974557e89",
-          "date": "2020-02-10T06:54:36+00:00",
-          "sha256": "0bmpv3rjdqmjjq4pb8qp4fyn2di05j91vp8ag9vsxwb8d6rgl55c",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/jiro4989/faker",
-          "rev": "916feb1d3b262c9bf710ff17a4e7f798c2a070ec",
-          "date": "2020-02-10T03:04:27+00:00",
-          "sha256": "0ximkgycy7zzic398agsdvfmbf6w64axqlcp23ia1lpqhzhlms7m",
           "fetchSubmodules": false
         }
       },

--- a/packages/fragments.json
+++ b/packages/fragments.json
@@ -4,66 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.1.9",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "eba861ce953eba85d8771bfbae84a3f51cb3f696",
-          "date": "2018-08-22T13:30:17+09:00",
-          "sha256": "1bdh07a6y4zwgn5jdg2zbhmxwbwhyna44n8ppcywpgp7yzkg75lj",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.8",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "ecde26cd44e53322a1c4ccba82413473864490bd",
-          "date": "2018-08-17T19:48:25+09:00",
-          "sha256": "13d5b77k1iin1cypfn0pfgwc2rapnybd0kmlcd862qhnw7sacf4s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.7",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "842cb3d7a0a4a42649f454c9223a9334f6340d95",
-          "date": "2018-08-17T19:47:32+09:00",
-          "sha256": "1hwgba68v8mcvin9p9avd6dmd6y4hhs5sw7bfw6bvd28aksvfvxb",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.6",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "bbfc27b76529e94553072d14f6a1d900612ba378",
-          "date": "2018-08-09T15:25:08+09:00",
-          "sha256": "02pi5wmwkr6qa1a5dlpxparxkdh50b3211hah51mgmcqv81rsh1r",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.5",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "e76807b2ddafe4e01c643784ef4dd007d6daa774",
-          "date": "2018-08-06T18:55:01+09:00",
-          "sha256": "0lw83znnyd8vpplvanlr6p0ibs7gdz5h5aa3gk5cin5gfnpny6jm",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.4",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "94e946ad83d2f1bf23f79b3d778439d97828d8b6",
-          "date": "2018-08-06T09:27:21+00:00",
-          "sha256": "1n2zpyi3hqjayxkpq8ssb5dscxy2r4w2fwzq9n75xrpzpf9f4rz7",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.1.39",
         "value": {
           "url": "https://github.com/fragcolor-xyz/fragments",
@@ -160,16 +100,6 @@
           "rev": "76983625a9ac3b8cb59233548c30f791021d29e8",
           "date": "2019-02-11T23:02:26+09:00",
           "sha256": "197vw61s38dh48618vq11x4cl60qm2da9h78d9c3prl8ax7bwzrh",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.3",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/fragments",
-          "rev": "6fd187d1f238114c0f950e45362a8ac611909fb4",
-          "date": "2018-07-30T09:16:58+02:00",
-          "sha256": "1ynipjjc7h59gzsfvcpzmb25y8fwnyn5nca29hb51azs3jzpxvfv",
           "fetchSubmodules": false
         }
       },
@@ -340,6 +270,76 @@
           "rev": "88d2fe70c86581732780357999aae5089450dcf8",
           "date": "2018-08-22T15:27:24+09:00",
           "sha256": "0393ni7kggzxmzjndfkvx963a2r54gw1fkqda89p96nzwylw31d7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.9",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "eba861ce953eba85d8771bfbae84a3f51cb3f696",
+          "date": "2018-08-22T13:30:17+09:00",
+          "sha256": "1bdh07a6y4zwgn5jdg2zbhmxwbwhyna44n8ppcywpgp7yzkg75lj",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.8",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "ecde26cd44e53322a1c4ccba82413473864490bd",
+          "date": "2018-08-17T19:48:25+09:00",
+          "sha256": "13d5b77k1iin1cypfn0pfgwc2rapnybd0kmlcd862qhnw7sacf4s",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.7",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "842cb3d7a0a4a42649f454c9223a9334f6340d95",
+          "date": "2018-08-17T19:47:32+09:00",
+          "sha256": "1hwgba68v8mcvin9p9avd6dmd6y4hhs5sw7bfw6bvd28aksvfvxb",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.6",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "bbfc27b76529e94553072d14f6a1d900612ba378",
+          "date": "2018-08-09T15:25:08+09:00",
+          "sha256": "02pi5wmwkr6qa1a5dlpxparxkdh50b3211hah51mgmcqv81rsh1r",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.5",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "e76807b2ddafe4e01c643784ef4dd007d6daa774",
+          "date": "2018-08-06T18:55:01+09:00",
+          "sha256": "0lw83znnyd8vpplvanlr6p0ibs7gdz5h5aa3gk5cin5gfnpny6jm",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.4",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "94e946ad83d2f1bf23f79b3d778439d97828d8b6",
+          "date": "2018-08-06T09:27:21+00:00",
+          "sha256": "1n2zpyi3hqjayxkpq8ssb5dscxy2r4w2fwzq9n75xrpzpf9f4rz7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.3",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/fragments",
+          "rev": "6fd187d1f238114c0f950e45362a8ac611909fb4",
+          "date": "2018-07-30T09:16:58+02:00",
+          "sha256": "1ynipjjc7h59gzsfvcpzmb25y8fwnyn5nca29hb51azs3jzpxvfv",
           "fetchSubmodules": false
         }
       },

--- a/packages/fugitive.json
+++ b/packages/fugitive.json
@@ -4,6 +4,52 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.11.1",
+        "value": {
+          "url": "https://github.com/citycide/fugitive",
+          "rev": "79f534a5f4f53d8da06433254aaed867bca1d3eb",
+          "date": "2020-11-09T16:44:19-06:00",
+          "path": "/nix/store/y2id84gchanlilgylna3lchdvwhjj4g2-fugitive",
+          "sha256": "0vxaq2wb0zaq05c666iyka902r3g59iia1sy3nidpv700cb0fddw",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/citycide/fugitive",
+          "rev": "3bca4a922bb8ce5cc28d444246527b194fa80f77",
+          "date": "2020-11-09T16:27:33-06:00",
+          "path": "/nix/store/72wb8wwlzlipc1cxxjywdg8lbwcgzgg9-fugitive",
+          "sha256": "1whqpa09szbjp8ckpn57ca8vxijaf88g3pwk4d8f77zfvyh7wc6x",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/citycide/fugitive",
+          "rev": "5e59a0b35ab457aa6fc19f79f88a1365d44acb12",
+          "date": "2019-01-03T23:15:08-06:00",
+          "sha256": "1wi8j9dzwp2dgcqdzdkl99q4mkqfk39bgwk06vrsa00k9iawbpyc",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/citycide/fugitive",
+          "rev": "d43a5c3a52f8e2b1b1feb4730760fa000afb0cb0",
+          "date": "2018-12-17T00:25:12-06:00",
+          "sha256": "1xn0v49yvgpqn9sg7zxv9xxfqgg2parqgai3qfj50bsi2b26v92i",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.0",
         "value": {
           "url": "https://github.com/citycide/fugitive",
@@ -110,52 +156,6 @@
           "rev": "b349a6fac810ebd8e7d1ced3288351b363d03e46",
           "date": "2018-05-15T22:36:05-05:00",
           "sha256": "0il92r2dfhrs89j52wj12lr9dwq7dfhpsk677zj4k5j2ljbzag9x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.1",
-        "value": {
-          "url": "https://github.com/citycide/fugitive",
-          "rev": "79f534a5f4f53d8da06433254aaed867bca1d3eb",
-          "date": "2020-11-09T16:44:19-06:00",
-          "path": "/nix/store/y2id84gchanlilgylna3lchdvwhjj4g2-fugitive",
-          "sha256": "0vxaq2wb0zaq05c666iyka902r3g59iia1sy3nidpv700cb0fddw",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/citycide/fugitive",
-          "rev": "3bca4a922bb8ce5cc28d444246527b194fa80f77",
-          "date": "2020-11-09T16:27:33-06:00",
-          "path": "/nix/store/72wb8wwlzlipc1cxxjywdg8lbwcgzgg9-fugitive",
-          "sha256": "1whqpa09szbjp8ckpn57ca8vxijaf88g3pwk4d8f77zfvyh7wc6x",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/citycide/fugitive",
-          "rev": "5e59a0b35ab457aa6fc19f79f88a1365d44acb12",
-          "date": "2019-01-03T23:15:08-06:00",
-          "sha256": "1wi8j9dzwp2dgcqdzdkl99q4mkqfk39bgwk06vrsa00k9iawbpyc",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/citycide/fugitive",
-          "rev": "d43a5c3a52f8e2b1b1feb4730760fa000afb0cb0",
-          "date": "2018-12-17T00:25:12-06:00",
-          "sha256": "1xn0v49yvgpqn9sg7zxv9xxfqgg2parqgai3qfj50bsi2b26v92i",
           "fetchSubmodules": false
         }
       },

--- a/packages/ggplotnim.json
+++ b/packages/ggplotnim.json
@@ -14,97 +14,6 @@
         }
       },
       {
-        "name": "0.3.9",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "7d9ee89f2fc1d0e948f398709f3cbc835228b3c4",
-          "date": "2020-06-15T18:15:34+02:00",
-          "path": "/nix/store/scyqb9i6rk6kczdynvra5dk4xrxfiabp-ggplotnim",
-          "sha256": "155pcdg51alrmjri5md94w131rdbgqylhh0virb1dgq879svyvd4",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.8",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "7a82562314b0e77ff582e8a90a9a4d0c6ef3352c",
-          "date": "2020-06-06T19:28:31+02:00",
-          "path": "/nix/store/x6d6qcjq2fskbqj2k9blhinhasiypw2d-ggplotnim",
-          "sha256": "18cffhx997r30rz6vxssqjkqz773jh8hc3n61xcg4j67513ib2vr",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.7",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "85c35e9823cbf2effd898d16c0937abd16f61b21",
-          "date": "2020-05-15T17:37:27+02:00",
-          "path": "/nix/store/higzzm86y6zqkqksy23y5fnbzzg3agkp-ggplotnim",
-          "sha256": "0d9prya1i78ikvd9l1galhwywawqsrjkbldasv90w8na9jav2fxl",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.6",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "ac7ebb23833a4a191152b509f14a6e759bec76bd",
-          "date": "2020-05-15T15:17:19+02:00",
-          "path": "/nix/store/vndbb17fps96pmvv1pnimbxq5c50rqh6-ggplotnim",
-          "sha256": "16vm95h07sy5ri9pnjnymsj5i7mnwj5mnfmwzkpaplg69arqj6ss",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.5",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "49a36bf0fd28562043796f8018a16a52579f1188",
-          "date": "2020-04-26T13:36:20+02:00",
-          "path": "/nix/store/di0ij1naqdvwvn3c93mfch2mrsazr8qm-ggplotnim",
-          "sha256": "0yl1dz9r17zppbzh9lcxfz2zwwgdpnw2m1hg36v5g8w8l95jcnzs",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.4",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "856ba4afaf9e3815b31ff3e21f1ffcc993e5dc12",
-          "date": "2020-04-21T20:50:19+02:00",
-          "path": "/nix/store/dlqa1qcfqbpz6bhncfq7s05b6qv9lwvp-ggplotnim",
-          "sha256": "0gfm7lb62nyikc0vamdip73nqyd40vgsvxzs5swkswqal05hbw9j",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.3",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "5155fbd12a9dce98fe387e1c30482b20ef42e057",
-          "date": "2020-04-18T10:50:09+02:00",
-          "path": "/nix/store/11xf6gjxa7yy5809f9vp7dr7pzj228f5-ggplotnim",
-          "sha256": "1r2330hanhcik33q3mwcmp90gcgmzc87068q6mc344z4yy78nwig",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "0.3.20",
         "value": {
           "url": "https://github.com/Vindaar/ggplotnim",
@@ -112,19 +21,6 @@
           "date": "2020-10-31T10:29:43+01:00",
           "path": "/nix/store/b1ccr496c5b1p03bay4vf6knvv0a0ng0-ggplotnim",
           "sha256": "0x75lnann25v3j5c5nq39rm4r92bzbfj9qhdvg7r4bg6fwf99x8q",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.2",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "a431c30e0e336812cdb24dc3607ab4f82e038fae",
-          "date": "2020-04-16T16:20:44+02:00",
-          "path": "/nix/store/ddzfiy10p51rw7aaqxyccmdzqgyljb4k-ggplotnim",
-          "sha256": "0z0pyn3a954qs76c2ywxnqr0c4fm2y9ybsfv4lvvgi1g97faqxrl",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
@@ -248,6 +144,110 @@
         }
       },
       {
+        "name": "0.3.9",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "7d9ee89f2fc1d0e948f398709f3cbc835228b3c4",
+          "date": "2020-06-15T18:15:34+02:00",
+          "path": "/nix/store/scyqb9i6rk6kczdynvra5dk4xrxfiabp-ggplotnim",
+          "sha256": "155pcdg51alrmjri5md94w131rdbgqylhh0virb1dgq879svyvd4",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.8",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "7a82562314b0e77ff582e8a90a9a4d0c6ef3352c",
+          "date": "2020-06-06T19:28:31+02:00",
+          "path": "/nix/store/x6d6qcjq2fskbqj2k9blhinhasiypw2d-ggplotnim",
+          "sha256": "18cffhx997r30rz6vxssqjkqz773jh8hc3n61xcg4j67513ib2vr",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.7",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "85c35e9823cbf2effd898d16c0937abd16f61b21",
+          "date": "2020-05-15T17:37:27+02:00",
+          "path": "/nix/store/higzzm86y6zqkqksy23y5fnbzzg3agkp-ggplotnim",
+          "sha256": "0d9prya1i78ikvd9l1galhwywawqsrjkbldasv90w8na9jav2fxl",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.6",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "ac7ebb23833a4a191152b509f14a6e759bec76bd",
+          "date": "2020-05-15T15:17:19+02:00",
+          "path": "/nix/store/vndbb17fps96pmvv1pnimbxq5c50rqh6-ggplotnim",
+          "sha256": "16vm95h07sy5ri9pnjnymsj5i7mnwj5mnfmwzkpaplg69arqj6ss",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.5",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "49a36bf0fd28562043796f8018a16a52579f1188",
+          "date": "2020-04-26T13:36:20+02:00",
+          "path": "/nix/store/di0ij1naqdvwvn3c93mfch2mrsazr8qm-ggplotnim",
+          "sha256": "0yl1dz9r17zppbzh9lcxfz2zwwgdpnw2m1hg36v5g8w8l95jcnzs",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.4",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "856ba4afaf9e3815b31ff3e21f1ffcc993e5dc12",
+          "date": "2020-04-21T20:50:19+02:00",
+          "path": "/nix/store/dlqa1qcfqbpz6bhncfq7s05b6qv9lwvp-ggplotnim",
+          "sha256": "0gfm7lb62nyikc0vamdip73nqyd40vgsvxzs5swkswqal05hbw9j",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.3",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "5155fbd12a9dce98fe387e1c30482b20ef42e057",
+          "date": "2020-04-18T10:50:09+02:00",
+          "path": "/nix/store/11xf6gjxa7yy5809f9vp7dr7pzj228f5-ggplotnim",
+          "sha256": "1r2330hanhcik33q3mwcmp90gcgmzc87068q6mc344z4yy78nwig",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.2",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "a431c30e0e336812cdb24dc3607ab4f82e038fae",
+          "date": "2020-04-16T16:20:44+02:00",
+          "path": "/nix/store/ddzfiy10p51rw7aaqxyccmdzqgyljb4k-ggplotnim",
+          "sha256": "0z0pyn3a954qs76c2ywxnqr0c4fm2y9ybsfv4lvvgi1g97faqxrl",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.3.1",
         "value": {
           "url": "https://github.com/Vindaar/ggplotnim",
@@ -274,92 +274,12 @@
         }
       },
       {
-        "name": "0.2.9",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "b736f1fc5027a7613b8309ef774422866042685e",
-          "date": "2020-02-20T17:29:44+01:00",
-          "sha256": "0nl40ahf255i394r7npyhllw9bf4jmdg0ysm9v9smlcf0h6xaqpk",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.8",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "218ac9479522a8673932dddeec91098dab16f1a0",
-          "date": "2020-02-18T14:01:39+01:00",
-          "sha256": "1gk71bpamsain4riw588v5x8c0v5gz53bvb19rgccmry5fzfylai",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.7",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "c9e3032a93e2b6bb04ff4bf78cef2f5ac1ecd384",
-          "date": "2020-02-14T18:47:47+01:00",
-          "sha256": "0dbf3qq1325f2hkybxhjhl3ncbf3187dbr0i2hncfcv1iqqjl967",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.6",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "68bc4134fa0d88dd3bf811bac727dd112da7d1e4",
-          "date": "2020-01-24T21:13:49+01:00",
-          "sha256": "0j95ab7i1b7x6snqk0b2z369mbdvv67yalnv9zpr6m3z0xpbz788",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.5",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "7161b96333820359f980c1192ede263e2edcf6b9",
-          "date": "2020-01-21T15:25:01+01:00",
-          "sha256": "0hz4da7m2f8iqqa8s7hd1qig08sqmmjhfqd4c66k3kh0dgzyg7jd",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.4",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "1e62e8bc324c0b7ab9f5f25be4c9f26e5bd3f62b",
-          "date": "2020-01-20T14:06:19+01:00",
-          "sha256": "1zz3wfmzss1fwac3sndk9s4pna3d92rbw7cj4gnx0ahzhq5ql01x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.3",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "43c514b5cd2b466db13eb00b384c2e31a9f99588",
-          "date": "2020-01-19T15:55:29+01:00",
-          "sha256": "0xl95d48ybxqcr1ls309l0cvb4f3zd9wnn3kdzqhxcjmwsqrgw3v",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.2.20",
         "value": {
           "url": "https://github.com/Vindaar/ggplotnim",
           "rev": "b081fe4788988e7c83e1510621b6b97281483697",
           "date": "2020-03-22T18:51:30+01:00",
           "sha256": "1lb2k17ybjvlm4vfx08wisgqhs8yy3svqq67h3yhysncnsfhgl2x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.2",
-        "value": {
-          "url": "https://github.com/Vindaar/ggplotnim",
-          "rev": "fd927f9cff6cee9f8e1cac173c686ad88f646f28",
-          "date": "2019-11-24T20:46:48+01:00",
-          "sha256": "0svqv6sc2yz00yqyzz75pw0b7rrqr7x9q70nrfg4j0ibb5mrhv47",
           "fetchSubmodules": false
         }
       },
@@ -460,6 +380,86 @@
           "rev": "11b83ec24ebb310a645bb1cc934cb910ed339baf",
           "date": "2020-02-22T21:10:38+01:00",
           "sha256": "105gcl014myfamqawnxj75q3acvw4xfjd2y0qfj20wnsgypsl2nq",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.9",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "b736f1fc5027a7613b8309ef774422866042685e",
+          "date": "2020-02-20T17:29:44+01:00",
+          "sha256": "0nl40ahf255i394r7npyhllw9bf4jmdg0ysm9v9smlcf0h6xaqpk",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.8",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "218ac9479522a8673932dddeec91098dab16f1a0",
+          "date": "2020-02-18T14:01:39+01:00",
+          "sha256": "1gk71bpamsain4riw588v5x8c0v5gz53bvb19rgccmry5fzfylai",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.7",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "c9e3032a93e2b6bb04ff4bf78cef2f5ac1ecd384",
+          "date": "2020-02-14T18:47:47+01:00",
+          "sha256": "0dbf3qq1325f2hkybxhjhl3ncbf3187dbr0i2hncfcv1iqqjl967",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.6",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "68bc4134fa0d88dd3bf811bac727dd112da7d1e4",
+          "date": "2020-01-24T21:13:49+01:00",
+          "sha256": "0j95ab7i1b7x6snqk0b2z369mbdvv67yalnv9zpr6m3z0xpbz788",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.5",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "7161b96333820359f980c1192ede263e2edcf6b9",
+          "date": "2020-01-21T15:25:01+01:00",
+          "sha256": "0hz4da7m2f8iqqa8s7hd1qig08sqmmjhfqd4c66k3kh0dgzyg7jd",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.4",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "1e62e8bc324c0b7ab9f5f25be4c9f26e5bd3f62b",
+          "date": "2020-01-20T14:06:19+01:00",
+          "sha256": "1zz3wfmzss1fwac3sndk9s4pna3d92rbw7cj4gnx0ahzhq5ql01x",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.3",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "43c514b5cd2b466db13eb00b384c2e31a9f99588",
+          "date": "2020-01-19T15:55:29+01:00",
+          "sha256": "0xl95d48ybxqcr1ls309l0cvb4f3zd9wnn3kdzqhxcjmwsqrgw3v",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.2",
+        "value": {
+          "url": "https://github.com/Vindaar/ggplotnim",
+          "rev": "fd927f9cff6cee9f8e1cac173c686ad88f646f28",
+          "date": "2019-11-24T20:46:48+01:00",
+          "sha256": "0svqv6sc2yz00yqyzz75pw0b7rrqr7x9q70nrfg4j0ibb5mrhv47",
           "fetchSubmodules": false
         }
       },

--- a/packages/ginger.json
+++ b/packages/ginger.json
@@ -108,86 +108,6 @@
         }
       },
       {
-        "name": "0.1.9",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "ce6d1d7ec7d82bb2374c631ba1cc43065600b174",
-          "date": "2020-02-26T16:34:26+01:00",
-          "sha256": "14a9fxjipgpz40l5yax2m3x8kppy808ibn3vin2jqhza1xhj6v85",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.8",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "1a37bfbef9d1f2fb2402dd890c8e7f9463a77dcf",
-          "date": "2020-02-19T14:55:37+01:00",
-          "sha256": "0735x36xm218cbxcb5f8v5jnzidc6zvs6zhwa6m6cc18mv243m06",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.7",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "bd481c187cc752b2ba8782fe3d8f3935e51b92a7",
-          "date": "2020-01-24T20:49:54+01:00",
-          "sha256": "1dhgpris4l9jlh5ilxqmrh2aiclrbdssaina97mw2q1krqf1hfld",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.6",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "0caf1fcbeb3cb5509e06c6b40587346bffd5f45e",
-          "date": "2019-11-24T20:35:38+01:00",
-          "sha256": "1cqazwlqrl6f608cj1xn4rwmf6y8scr8n69c6wiqjlfcbchf7ssw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.5",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "5d441d1acc805ce03d6ed557654b505537e99b6d",
-          "date": "2019-11-23T17:44:49+01:00",
-          "sha256": "12m0sjkhl1bwdj5lhmpz0hakfn7djfn29g910wqss7qxxqy7lqhc",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.4",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "be999e1c4923991dfd4171947071f9c456bb7a77",
-          "date": "2019-11-15T20:04:56+01:00",
-          "sha256": "1a8sfxf8ff2x5qi54h65dgrsg410zx1jz6vn1pp48v39yjw4d5ry",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.3",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "4991eaea87f21f88774a92bbde83fbe97ca9b621",
-          "date": "2019-11-05T15:52:59+01:00",
-          "sha256": "1kkgwwa8qb202brx1za76pnzx5b5856s80asvzadlir5yfd9p197",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.2",
-        "value": {
-          "url": "https://github.com/Vindaar/ginger",
-          "rev": "c89f0c7357ac5412a306179f45659387ba8829f7",
-          "date": "2019-11-05T14:02:48+01:00",
-          "sha256": "1cnsmp3q24kxk9d29cbmx3pdgh2ql2lfsr09jl4lmag0g83ppr2f",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.1.17",
         "value": {
           "url": "https://github.com/Vindaar/ginger",
@@ -264,6 +184,86 @@
           "rev": "c08be20707a7d15f251a1700205d9101522ed389",
           "date": "2020-03-03T17:12:11+01:00",
           "sha256": "0v8s8nb5n9p6p72d5jgwydsmxl767y7gsaaz5ky3qk87a1cxahgj",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.9",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "ce6d1d7ec7d82bb2374c631ba1cc43065600b174",
+          "date": "2020-02-26T16:34:26+01:00",
+          "sha256": "14a9fxjipgpz40l5yax2m3x8kppy808ibn3vin2jqhza1xhj6v85",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.8",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "1a37bfbef9d1f2fb2402dd890c8e7f9463a77dcf",
+          "date": "2020-02-19T14:55:37+01:00",
+          "sha256": "0735x36xm218cbxcb5f8v5jnzidc6zvs6zhwa6m6cc18mv243m06",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.7",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "bd481c187cc752b2ba8782fe3d8f3935e51b92a7",
+          "date": "2020-01-24T20:49:54+01:00",
+          "sha256": "1dhgpris4l9jlh5ilxqmrh2aiclrbdssaina97mw2q1krqf1hfld",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.6",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "0caf1fcbeb3cb5509e06c6b40587346bffd5f45e",
+          "date": "2019-11-24T20:35:38+01:00",
+          "sha256": "1cqazwlqrl6f608cj1xn4rwmf6y8scr8n69c6wiqjlfcbchf7ssw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.5",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "5d441d1acc805ce03d6ed557654b505537e99b6d",
+          "date": "2019-11-23T17:44:49+01:00",
+          "sha256": "12m0sjkhl1bwdj5lhmpz0hakfn7djfn29g910wqss7qxxqy7lqhc",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.4",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "be999e1c4923991dfd4171947071f9c456bb7a77",
+          "date": "2019-11-15T20:04:56+01:00",
+          "sha256": "1a8sfxf8ff2x5qi54h65dgrsg410zx1jz6vn1pp48v39yjw4d5ry",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.3",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "4991eaea87f21f88774a92bbde83fbe97ca9b621",
+          "date": "2019-11-05T15:52:59+01:00",
+          "sha256": "1kkgwwa8qb202brx1za76pnzx5b5856s80asvzadlir5yfd9p197",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.2",
+        "value": {
+          "url": "https://github.com/Vindaar/ginger",
+          "rev": "c89f0c7357ac5412a306179f45659387ba8829f7",
+          "date": "2019-11-05T14:02:48+01:00",
+          "sha256": "1cnsmp3q24kxk9d29cbmx3pdgh2ql2lfsr09jl4lmag0g83ppr2f",
           "fetchSubmodules": false
         }
       },

--- a/packages/gintro.json
+++ b/packages/gintro.json
@@ -254,76 +254,6 @@
         }
       },
       {
-        "name": "0.4.9",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "a4f845f987fed04316a941371c2e7e89ff2ab19a",
-          "date": "2019-02-10T11:56:27+01:00",
-          "sha256": "08f4sw69hvsc14q8cial5ypn0hsqjr1drlds0cllrnckd411wcc1",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.8",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "fb75f1512c7095f04639d15ce2c48ee4086a6755",
-          "date": "2019-01-15T21:45:26+01:00",
-          "sha256": "12j84ip383y5pc612dp34fydchnj8rdwp5wxvqkpxg8073avc9br",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.7",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "696a7952bf5449e4bb83fd3135e89ae1624d2d57",
-          "date": "2018-10-22T11:12:06+02:00",
-          "sha256": "16kzgzqjhdspdpr2kqhrxjrrvs6cha9a1kwvl5xgmvvkxbr1h2zi",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.6",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "f7e692dbe2edef5b3d655e03f3b8c2d86dce05e6",
-          "date": "2018-09-30T20:45:01+02:00",
-          "sha256": "0j5a0rn4flzl9wvdi6304y9r5xr9bb7rgkyispczxk4mr82kmcd7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.5",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "32b3018a7b51dc082ad4a972807f55ff5aaad6dd",
-          "date": "2018-08-20T08:09:56+02:00",
-          "sha256": "0i4rmqplil9a763hii4v8f11dlydv6z96pwhmlhvmcvyy8gnvv2v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.4",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "37f7ee9aceb866a3051db0aa919c3f736043e13b",
-          "date": "2018-08-02T16:31:54+02:00",
-          "sha256": "01lsw73d0dpdm9jia6qy1yda6r0bzbm6kj87zi6r1gzf8djnffrm",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.3",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "fa5226486998f507324a98098977c47ced922447",
-          "date": "2018-04-25T10:28:48+02:00",
-          "sha256": "1z2yn0hvqdp9r9jhcw1msxbwq3zlr6wnyfz8aa9ym8vfaa9vr5j9",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.4.23",
         "value": {
           "url": "https://github.com/stefansalewski/gintro",
@@ -350,16 +280,6 @@
           "rev": "d0f0f35bb1577fa5661deac3175b5adf66ab6e31",
           "date": "2019-06-05T17:42:07+02:00",
           "sha256": "0h69i0vq19s6qzxnkwlrzlznj4b7fc7r3rcn7qmcl431v0ywjn8a",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.2",
-        "value": {
-          "url": "https://github.com/stefansalewski/gintro",
-          "rev": "f4fd43950470869bd2e9fce944ada1b90749af5e",
-          "date": "2018-03-11T15:24:08+01:00",
-          "sha256": "0p7mw37iqcm3w02k39xfgdx2dbgib5f4b3sjyh6pa2f4zw4x6dvj",
           "fetchSubmodules": false
         }
       },
@@ -430,6 +350,86 @@
           "rev": "ac537bbe843b392a49958c10d142fc557f91e962",
           "date": "2019-02-10T13:10:26+01:00",
           "sha256": "172asb1y3xn504wi8vifa415dd27ifmxhvrcl5pcxl0kh75pxfk7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.9",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "a4f845f987fed04316a941371c2e7e89ff2ab19a",
+          "date": "2019-02-10T11:56:27+01:00",
+          "sha256": "08f4sw69hvsc14q8cial5ypn0hsqjr1drlds0cllrnckd411wcc1",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.8",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "fb75f1512c7095f04639d15ce2c48ee4086a6755",
+          "date": "2019-01-15T21:45:26+01:00",
+          "sha256": "12j84ip383y5pc612dp34fydchnj8rdwp5wxvqkpxg8073avc9br",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.7",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "696a7952bf5449e4bb83fd3135e89ae1624d2d57",
+          "date": "2018-10-22T11:12:06+02:00",
+          "sha256": "16kzgzqjhdspdpr2kqhrxjrrvs6cha9a1kwvl5xgmvvkxbr1h2zi",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.6",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "f7e692dbe2edef5b3d655e03f3b8c2d86dce05e6",
+          "date": "2018-09-30T20:45:01+02:00",
+          "sha256": "0j5a0rn4flzl9wvdi6304y9r5xr9bb7rgkyispczxk4mr82kmcd7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.5",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "32b3018a7b51dc082ad4a972807f55ff5aaad6dd",
+          "date": "2018-08-20T08:09:56+02:00",
+          "sha256": "0i4rmqplil9a763hii4v8f11dlydv6z96pwhmlhvmcvyy8gnvv2v",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.4",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "37f7ee9aceb866a3051db0aa919c3f736043e13b",
+          "date": "2018-08-02T16:31:54+02:00",
+          "sha256": "01lsw73d0dpdm9jia6qy1yda6r0bzbm6kj87zi6r1gzf8djnffrm",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.3",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "fa5226486998f507324a98098977c47ced922447",
+          "date": "2018-04-25T10:28:48+02:00",
+          "sha256": "1z2yn0hvqdp9r9jhcw1msxbwq3zlr6wnyfz8aa9ym8vfaa9vr5j9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.2",
+        "value": {
+          "url": "https://github.com/stefansalewski/gintro",
+          "rev": "f4fd43950470869bd2e9fce944ada1b90749af5e",
+          "date": "2018-03-11T15:24:08+01:00",
+          "sha256": "0p7mw37iqcm3w02k39xfgdx2dbgib5f4b3sjyh6pa2f4zw4x6dvj",
           "fetchSubmodules": false
         }
       },

--- a/packages/glob.json
+++ b/packages/glob.json
@@ -4,6 +4,19 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/citycide/glob",
+          "rev": "85fc1a2c6df8e05ddf63e39e47a5455543f3786a",
+          "date": "2020-11-10T22:03:54+00:00",
+          "path": "/nix/store/vjirklp7g11zdmv11lp6z6kpadhbrrbh-glob",
+          "sha256": "0j07bcs496fcs89ccrw8blhrs6iypqw5vils3sq3pgz7n8mzhr70",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.9.1",
         "value": {
           "url": "https://github.com/citycide/glob",
@@ -124,19 +137,6 @@
           "date": "2018-05-22T13:28:03+00:00",
           "sha256": "0yv5fi0ak2p5nlzjbhyp7xknx4cybsi76z4qswiw1j53dmwmc1k9",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/citycide/glob",
-          "rev": "85fc1a2c6df8e05ddf63e39e47a5455543f3786a",
-          "date": "2020-11-10T22:03:54+00:00",
-          "path": "/nix/store/vjirklp7g11zdmv11lp6z6kpadhbrrbh-glob",
-          "sha256": "0j07bcs496fcs89ccrw8blhrs6iypqw5vils3sq3pgz7n8mzhr70",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/godot.json
+++ b/packages/godot.json
@@ -30,76 +30,6 @@
         }
       },
       {
-        "name": "0.7.9",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "6e014bbc01a97aed1b5211e8ff17cae7a605eaa1",
-          "date": "2018-04-24T11:12:49+07:00",
-          "sha256": "0h3087b8i4dyqlhpfhbyxzm35zsvvwr0hrjavjz8dqvwgrh1ln4s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.8",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "dc6ebaf5757b82436d714a779855207c6009afe4",
-          "date": "2018-03-31T17:45:50+07:00",
-          "sha256": "1vgzkzqfs1xa1sbw1njlpk36r9y75pnqwmkkfn9a6ibffkg0qipw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.7",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "be6f01e3b7517f1a6dff17fb0fea84a1b7c94c03",
-          "date": "2018-02-22T18:55:52+07:00",
-          "sha256": "1dh7v9px8xnkcbrc3rxdqfq9r83c9l3fjqmg3knzsd941xn0jy78",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.6",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "d11856377e05212663c72dd06947f9e40456cff3",
-          "date": "2018-02-17T23:44:07+07:00",
-          "sha256": "1pnw9amb306inds4891qv391s6q28bn4c6khfyclbg1zdzhnpify",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.5",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "0aab6e17efd99253912889a222c7878ba3208e4c",
-          "date": "2018-01-31T20:52:15+07:00",
-          "sha256": "127y78wyq5yv88wz17k7jdhh31r91b71wn5jqyajc5n2d0jhmabc",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.4",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "f05eb090f710df4aed71e6502da8258c5abbb6d9",
-          "date": "2018-01-25T17:52:58+07:00",
-          "sha256": "02ccrgmhsbgznkq796vzcliaif9abzafzb5bi7ilhphad02rjar9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.3",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "ae3171cb98a1bf9e005615c0ced636590af4dc9b",
-          "date": "2018-01-15T11:01:48+07:00",
-          "sha256": "1sf2ri9zj16zw7d3n22h31kw59g6hfdy0n4iskpr2jy5amzmhswn",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.7.28",
         "value": {
           "url": "https://github.com/pragmagic/godot-nim",
@@ -189,16 +119,6 @@
           "rev": "f45281f5a0cdb9e1de482a047aa49156fbc8f92f",
           "date": "2019-09-12T18:59:11+07:00",
           "sha256": "1ad0fa1g3cz7gna1ybi9fp0zpkgzg0zbw4j915dflmwl2c8jpyv2",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.2",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "d4ab8a5524b767610e4b87787386af7ada801911",
-          "date": "2018-01-12T23:22:50+07:00",
-          "sha256": "0dvywagl461h86dc3nfgv3hb63fxcqs8k333ijsq635q8v87nlyf",
           "fetchSubmodules": false
         }
       },
@@ -293,6 +213,86 @@
         }
       },
       {
+        "name": "0.7.9",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "6e014bbc01a97aed1b5211e8ff17cae7a605eaa1",
+          "date": "2018-04-24T11:12:49+07:00",
+          "sha256": "0h3087b8i4dyqlhpfhbyxzm35zsvvwr0hrjavjz8dqvwgrh1ln4s",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.8",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "dc6ebaf5757b82436d714a779855207c6009afe4",
+          "date": "2018-03-31T17:45:50+07:00",
+          "sha256": "1vgzkzqfs1xa1sbw1njlpk36r9y75pnqwmkkfn9a6ibffkg0qipw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.7",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "be6f01e3b7517f1a6dff17fb0fea84a1b7c94c03",
+          "date": "2018-02-22T18:55:52+07:00",
+          "sha256": "1dh7v9px8xnkcbrc3rxdqfq9r83c9l3fjqmg3knzsd941xn0jy78",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.6",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "d11856377e05212663c72dd06947f9e40456cff3",
+          "date": "2018-02-17T23:44:07+07:00",
+          "sha256": "1pnw9amb306inds4891qv391s6q28bn4c6khfyclbg1zdzhnpify",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.5",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "0aab6e17efd99253912889a222c7878ba3208e4c",
+          "date": "2018-01-31T20:52:15+07:00",
+          "sha256": "127y78wyq5yv88wz17k7jdhh31r91b71wn5jqyajc5n2d0jhmabc",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.4",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "f05eb090f710df4aed71e6502da8258c5abbb6d9",
+          "date": "2018-01-25T17:52:58+07:00",
+          "sha256": "02ccrgmhsbgznkq796vzcliaif9abzafzb5bi7ilhphad02rjar9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.3",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "ae3171cb98a1bf9e005615c0ced636590af4dc9b",
+          "date": "2018-01-15T11:01:48+07:00",
+          "sha256": "1sf2ri9zj16zw7d3n22h31kw59g6hfdy0n4iskpr2jy5amzmhswn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.2",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "d4ab8a5524b767610e4b87787386af7ada801911",
+          "date": "2018-01-12T23:22:50+07:00",
+          "sha256": "0dvywagl461h86dc3nfgv3hb63fxcqs8k333ijsq635q8v87nlyf",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.7.1",
         "value": {
           "url": "https://github.com/pragmagic/godot-nim",
@@ -309,6 +309,26 @@
           "rev": "d89073bac8affc5b0d90ea7fe4078442d6aa4d3e",
           "date": "2017-12-29T11:52:00+07:00",
           "sha256": "0jxca0kfyqfwmhcwdilf6zsy1h38v87ly62c1qm6vzb8lc85da1g",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.11",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "e2feb0646889d908dc3a54ff57a285eaa01aa2f8",
+          "date": "2017-12-18T17:22:12+07:00",
+          "sha256": "0r19m62fkjwi5azyzfzjd33q432nm3ny8wqybgladyl2pzx3wgn9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.10",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "4d19140d7c8d1ae7ba84325d86351472cd87e187",
+          "date": "2017-12-18T13:48:01+07:00",
+          "sha256": "1shclcxp4zc1yawvd0dygzlykc6gxhx56n5v6w9flyvnhzl95jc7",
           "fetchSubmodules": false
         }
       },
@@ -373,26 +393,6 @@
         }
       },
       {
-        "name": "0.6.11",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "e2feb0646889d908dc3a54ff57a285eaa01aa2f8",
-          "date": "2017-12-18T17:22:12+07:00",
-          "sha256": "0r19m62fkjwi5azyzfzjd33q432nm3ny8wqybgladyl2pzx3wgn9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.10",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "4d19140d7c8d1ae7ba84325d86351472cd87e187",
-          "date": "2017-12-18T13:48:01+07:00",
-          "sha256": "1shclcxp4zc1yawvd0dygzlykc6gxhx56n5v6w9flyvnhzl95jc7",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.6.1",
         "value": {
           "url": "https://github.com/pragmagic/godot-nim",
@@ -409,6 +409,16 @@
           "rev": "54d962afd4e7dd7273c3ca917ef716838338aaff",
           "date": "2017-10-05T18:55:51+07:00",
           "sha256": "0q9ac5mgbllnz6pgbf9pmdzzwmprrs593z7lrddlilradchbrlas",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.10",
+        "value": {
+          "url": "https://github.com/pragmagic/godot-nim",
+          "rev": "cf75723fa154c75204807256483ac24833b9fced",
+          "date": "2017-09-19T18:26:55+07:00",
+          "sha256": "1i3lfah7ckblibhwwrrmrb31i235q4nqra7wyy7by8qqyzckcwdx",
           "fetchSubmodules": false
         }
       },
@@ -489,16 +499,6 @@
           "rev": "c5f6d47f3e07e236543ae70f99a2f0f6b75f949c",
           "date": "2017-08-14T20:22:08+07:00",
           "sha256": "1fjph1vag404qhqh83zk1ppmp03sdw0r3g5rpahvc6jr1ia5jj5z",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.10",
-        "value": {
-          "url": "https://github.com/pragmagic/godot-nim",
-          "rev": "cf75723fa154c75204807256483ac24833b9fced",
-          "date": "2017-09-19T18:26:55+07:00",
-          "sha256": "1i3lfah7ckblibhwwrrmrb31i235q4nqra7wyy7by8qqyzckcwdx",
           "fetchSubmodules": false
         }
       },

--- a/packages/golden.json
+++ b/packages/golden.json
@@ -4,6 +4,72 @@
     "method": "git",
     "versions": [
       {
+        "name": "3.0.15",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "2bfc46e1565655d6e6256d0f441377eb232adb00",
+          "date": "2020-07-06T17:28:53-04:00",
+          "path": "/nix/store/d34sl4jw0qzj9apcydhy1r3v66izavzx-golden",
+          "sha256": "1j80sz0p52x7gi4ls4095692lppgqmpcim7kfh9hqw62rjs0rfqa",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "3.0.14",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "e24ef5e75305cc71b10900a399700e2ffa0119c5",
+          "date": "2020-05-31T13:16:17-04:00",
+          "path": "/nix/store/vrcfrpw5bcqc2d2pg4cwc91hnal6i77x-golden",
+          "sha256": "19cqzk4l1zz1ah7a7ksvc6qjvs7yz070ax2xk9xpksl1c3rs3dij",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "3.0.13",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "32f598d149d7427ba2c0bb53069fc5e4a0a93717",
+          "date": "2020-02-05T01:56:04-05:00",
+          "sha256": "180ils9as7iyz988ihqq1k83dg5qw2m39mxnlyiaj9z02slad6hs",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "3.0.12",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "479ec6aad7a45f33e8637b34a62b4856d0a67f40",
+          "date": "2019-12-11T21:56:24-05:00",
+          "sha256": "1xnzziq6xqgr1w5mm0bgjd8jjax3anzn5wq1dxs6wr97ap65hglx",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "3.0.11",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "b57faa543e7484c51b1d2de615ad7a8be8ad9fcf",
+          "date": "2019-12-11T11:24:37-05:00",
+          "sha256": "1p4v5nysn8qasd0lyr67jlwypz245j56q0hdxx890p4pkh7wm21s",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "3.0.10",
+        "value": {
+          "url": "https://github.com/disruptek/golden",
+          "rev": "647f8ff0819812674c72d450db36660cfac17f95",
+          "date": "2019-12-11T11:10:36-05:00",
+          "sha256": "1c70hlbyrr3y6sz1ag1z3pz2q37j1y8xr6l22jnk99cpgp671lvh",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "3.0.9",
         "value": {
           "url": "https://github.com/disruptek/golden",
@@ -80,72 +146,6 @@
           "rev": "146f6f2ba297d42e81bfadabafb558a51200dbd2",
           "date": "2019-11-14T22:03:37-05:00",
           "sha256": "05sfy6fimqvmv06m5ahkdl491xjcjlhdrl8wij9c2gwgwivzghqq",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "3.0.15",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "2bfc46e1565655d6e6256d0f441377eb232adb00",
-          "date": "2020-07-06T17:28:53-04:00",
-          "path": "/nix/store/d34sl4jw0qzj9apcydhy1r3v66izavzx-golden",
-          "sha256": "1j80sz0p52x7gi4ls4095692lppgqmpcim7kfh9hqw62rjs0rfqa",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "3.0.14",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "e24ef5e75305cc71b10900a399700e2ffa0119c5",
-          "date": "2020-05-31T13:16:17-04:00",
-          "path": "/nix/store/vrcfrpw5bcqc2d2pg4cwc91hnal6i77x-golden",
-          "sha256": "19cqzk4l1zz1ah7a7ksvc6qjvs7yz070ax2xk9xpksl1c3rs3dij",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "3.0.13",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "32f598d149d7427ba2c0bb53069fc5e4a0a93717",
-          "date": "2020-02-05T01:56:04-05:00",
-          "sha256": "180ils9as7iyz988ihqq1k83dg5qw2m39mxnlyiaj9z02slad6hs",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "3.0.12",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "479ec6aad7a45f33e8637b34a62b4856d0a67f40",
-          "date": "2019-12-11T21:56:24-05:00",
-          "sha256": "1xnzziq6xqgr1w5mm0bgjd8jjax3anzn5wq1dxs6wr97ap65hglx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "3.0.11",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "b57faa543e7484c51b1d2de615ad7a8be8ad9fcf",
-          "date": "2019-12-11T11:24:37-05:00",
-          "sha256": "1p4v5nysn8qasd0lyr67jlwypz245j56q0hdxx890p4pkh7wm21s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "3.0.10",
-        "value": {
-          "url": "https://github.com/disruptek/golden",
-          "rev": "647f8ff0819812674c72d450db36660cfac17f95",
-          "date": "2019-12-11T11:10:36-05:00",
-          "sha256": "1c70hlbyrr3y6sz1ag1z3pz2q37j1y8xr6l22jnk99cpgp671lvh",
           "fetchSubmodules": false
         }
       },

--- a/packages/hastyscribe.json
+++ b/packages/hastyscribe.json
@@ -4,6 +4,78 @@
     "method": "git",
     "versions": [
       {
+        "name": "1.12.3",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "9650e8c032ce343ce6089384efbcd865277841e4",
+          "date": "2020-11-05T13:10:25+00:00",
+          "path": "/nix/store/rah3gnh851h03qw5i7s7r9d8hba2lp1x-hastyscribe",
+          "sha256": "17157h3di9p3zl40mlrgyd169phri86ibhws42h065hs73vx3m9l",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.12.2",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "669a56eb5d1018a4e3c224312e6676e6dc249439",
+          "date": "2020-10-25T16:58:25+01:00",
+          "path": "/nix/store/20frca4cs45ac2ym39g307vkxwy1szqb-hastyscribe",
+          "sha256": "1ns8fypijgyzhxljb5ynshbvsljdmdxddw91m7fw0hnh77qcfg2m",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.12.1",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "892c1bfdf5131a624e93ea847a05a1e8d67e52e8",
+          "date": "2020-08-30T12:31:04+02:00",
+          "path": "/nix/store/kjjkwpj2027xrmwdq0xlr2cmql70w8sl-hastyscribe",
+          "sha256": "03szqm2v147s6an2l88r84lsh9df6jpdc71q6mrysig9dadxrg80",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.12.0",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "0f51354bd244e6da2642176173098df34ae59df1",
+          "date": "2020-04-16T18:07:24+02:00",
+          "path": "/nix/store/lz3hw98q8gm8i36vhm6cmnjnf43kayrg-hastyscribe",
+          "sha256": "1h4pjc5lrynjvl7qim992lz2wxsm33qkcjkfsnyw7kn011dxcgk1",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.11.0",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "39cd9408fdcbfc8590b98ed4e1607b2a8b18cd2f",
+          "date": "2018-10-07T19:15:46+02:00",
+          "sha256": "1cpz8pjbn0qsz81x91y45yz2b70mi07d4k6b4a6ng7m9fx39yrpn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.10.0",
+        "value": {
+          "url": "https://github.com/h3rald/hastyscribe",
+          "rev": "508136dc1ce3c0bffeb69d2c4ffecebaeb6d28ab",
+          "date": "2018-04-29T15:45:49+02:00",
+          "sha256": "0wrx5iln4a5cs4y2kzfi5b79x6ci58hfnqdw0s9wnpvwb6mwcjfs",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "1.9.0",
         "value": {
           "url": "https://github.com/h3rald/hastyscribe",
@@ -100,78 +172,6 @@
           "rev": "b22e10e136d9214f995be9138e359e4a8729b8ac",
           "date": "2016-06-11T14:44:08+02:00",
           "sha256": "1rnpn92kja38xa6lpvh9b28pikf07895nhabdriz379cy06zd10j",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.12.3",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "9650e8c032ce343ce6089384efbcd865277841e4",
-          "date": "2020-11-05T13:10:25+00:00",
-          "path": "/nix/store/rah3gnh851h03qw5i7s7r9d8hba2lp1x-hastyscribe",
-          "sha256": "17157h3di9p3zl40mlrgyd169phri86ibhws42h065hs73vx3m9l",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.12.2",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "669a56eb5d1018a4e3c224312e6676e6dc249439",
-          "date": "2020-10-25T16:58:25+01:00",
-          "path": "/nix/store/20frca4cs45ac2ym39g307vkxwy1szqb-hastyscribe",
-          "sha256": "1ns8fypijgyzhxljb5ynshbvsljdmdxddw91m7fw0hnh77qcfg2m",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.12.1",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "892c1bfdf5131a624e93ea847a05a1e8d67e52e8",
-          "date": "2020-08-30T12:31:04+02:00",
-          "path": "/nix/store/kjjkwpj2027xrmwdq0xlr2cmql70w8sl-hastyscribe",
-          "sha256": "03szqm2v147s6an2l88r84lsh9df6jpdc71q6mrysig9dadxrg80",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.12.0",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "0f51354bd244e6da2642176173098df34ae59df1",
-          "date": "2020-04-16T18:07:24+02:00",
-          "path": "/nix/store/lz3hw98q8gm8i36vhm6cmnjnf43kayrg-hastyscribe",
-          "sha256": "1h4pjc5lrynjvl7qim992lz2wxsm33qkcjkfsnyw7kn011dxcgk1",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.11.0",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "39cd9408fdcbfc8590b98ed4e1607b2a8b18cd2f",
-          "date": "2018-10-07T19:15:46+02:00",
-          "sha256": "1cpz8pjbn0qsz81x91y45yz2b70mi07d4k6b4a6ng7m9fx39yrpn",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.10.0",
-        "value": {
-          "url": "https://github.com/h3rald/hastyscribe",
-          "rev": "508136dc1ce3c0bffeb69d2c4ffecebaeb6d28ab",
-          "date": "2018-04-29T15:45:49+02:00",
-          "sha256": "0wrx5iln4a5cs4y2kzfi5b79x6ci58hfnqdw0s9wnpvwb6mwcjfs",
           "fetchSubmodules": false
         }
       },

--- a/packages/hmisc.json
+++ b/packages/hmisc.json
@@ -4,6 +4,19 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.9.7",
+        "value": {
+          "url": "https://github.com/haxscramper/hmisc",
+          "rev": "90aa6d4637432cf18ef99db9f51485e5ff546fce",
+          "date": "2020-12-14T02:01:45+03:00",
+          "path": "/nix/store/sr4smgy1sy8dzwjjvvvrlgjzq5wi7vxw-hmisc",
+          "sha256": "03kis8vz0iscngwcfbnx3g4jl9w6dvnmc4fl2fr4g25fk4q4zijj",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.9.6",
         "value": {
           "url": "https://github.com/haxscramper/hmisc",
@@ -89,6 +102,19 @@
           "date": "2020-12-02T00:11:35+03:00",
           "path": "/nix/store/qk9vymalkcczazxs506sybdz57hcn5wj-hmisc",
           "sha256": "0vdv651n9m7c9jfkn3p7xysrf5fc4lk9vw80zws3ig5p4ws8jzgq",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.8.10",
+        "value": {
+          "url": "https://github.com/haxscramper/hmisc",
+          "rev": "d66409c8994cd11afb05fe8fbb77b2ca8b877d65",
+          "date": "2020-11-25T11:42:41+03:00",
+          "path": "/nix/store/x1k30ibz89ysj5rs2z5fff46s9cbzbm5-hmisc",
+          "sha256": "12gvai0x4xg4xpha62481w8awqdfij7vfmg4naq35827kwk7ynw6",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
@@ -193,19 +219,6 @@
           "date": "2020-10-25T23:43:12+03:00",
           "path": "/nix/store/975383ipdmwiscpv7xq971zkn0yrc30m-hmisc",
           "sha256": "158xzl7wg06l26xsl39xik7w2qx3iwmqnh3x0mxmqb4a8mp17imh",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.8.10",
-        "value": {
-          "url": "https://github.com/haxscramper/hmisc",
-          "rev": "d66409c8994cd11afb05fe8fbb77b2ca8b877d65",
-          "date": "2020-11-25T11:42:41+03:00",
-          "path": "/nix/store/x1k30ibz89ysj5rs2z5fff46s9cbzbm5-hmisc",
-          "sha256": "12gvai0x4xg4xpha62481w8awqdfij7vfmg4naq35827kwk7ynw6",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/packages/hts.json
+++ b/packages/hts.json
@@ -4,6 +4,71 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.3.14",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "13ccd2838a3d5e58991ff4cd50fe7ed41b434583",
+          "date": "2020-11-24T20:19:05-07:00",
+          "path": "/nix/store/alqgy8j0k2vwsjpc084rjy8d5g46jbdp-hts-nim",
+          "sha256": "0s5m1mhsx1hkgva3hjx37cak30bsqjdvq68qprb5z62a6svwmn65",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.13",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "3c4ce10417faf86c70ddd3467930d7e5a9af847b",
+          "date": "2020-11-22T16:10:16-07:00",
+          "path": "/nix/store/9w0jvl3najhc5ap6ch8qnyyqpy66vxbx-hts-nim",
+          "sha256": "1a3y2893v8kjl9rxdxk8wd4fdj5jngl7076gkn78g5ngv772dz6f",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.12",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "9ec538a30f18edc7da9914ee2b48bccd245bfb50",
+          "date": "2020-09-20T12:50:01-07:00",
+          "path": "/nix/store/bqhqn99gfnhadsmc5z5lx5dbw18mbf47-hts-nim",
+          "sha256": "0jl01j43g34k3jxkp1f7mz18d7qqfsgxfwxg4c6apfgk3zfrxnnh",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.11",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "eaec7001054c279fbd3af4410cccb1ebb36de43c",
+          "date": "2020-07-28T13:10:20-06:00",
+          "path": "/nix/store/8c49qazmxing5179q63ikfkrjwx6c91m-hts-nim",
+          "sha256": "1hnb14frxmqcwigan78qdpmmdmwh1fb7driklp4alc19myrx8cmc",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.10",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "fdffeb96218b3953ca884a5af5aa694745bd4196",
+          "date": "2020-06-26T07:36:00-06:00",
+          "path": "/nix/store/yh4h2ibv6kq7lhsyn3jhp7y99v85y2nc-hts-nim",
+          "sha256": "17vi2dbrq5annq2mfpg5pkij29qywdyw0771jwzjy266fgnhrl4f",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.3.9",
         "value": {
           "url": "https://github.com/brentp/hts-nim",
@@ -99,107 +164,12 @@
         }
       },
       {
-        "name": "0.3.14",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "13ccd2838a3d5e58991ff4cd50fe7ed41b434583",
-          "date": "2020-11-24T20:19:05-07:00",
-          "path": "/nix/store/alqgy8j0k2vwsjpc084rjy8d5g46jbdp-hts-nim",
-          "sha256": "0s5m1mhsx1hkgva3hjx37cak30bsqjdvq68qprb5z62a6svwmn65",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.13",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "3c4ce10417faf86c70ddd3467930d7e5a9af847b",
-          "date": "2020-11-22T16:10:16-07:00",
-          "path": "/nix/store/9w0jvl3najhc5ap6ch8qnyyqpy66vxbx-hts-nim",
-          "sha256": "1a3y2893v8kjl9rxdxk8wd4fdj5jngl7076gkn78g5ngv772dz6f",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.12",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "9ec538a30f18edc7da9914ee2b48bccd245bfb50",
-          "date": "2020-09-20T12:50:01-07:00",
-          "path": "/nix/store/bqhqn99gfnhadsmc5z5lx5dbw18mbf47-hts-nim",
-          "sha256": "0jl01j43g34k3jxkp1f7mz18d7qqfsgxfwxg4c6apfgk3zfrxnnh",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.11",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "eaec7001054c279fbd3af4410cccb1ebb36de43c",
-          "date": "2020-07-28T13:10:20-06:00",
-          "path": "/nix/store/8c49qazmxing5179q63ikfkrjwx6c91m-hts-nim",
-          "sha256": "1hnb14frxmqcwigan78qdpmmdmwh1fb7driklp4alc19myrx8cmc",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.10",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "fdffeb96218b3953ca884a5af5aa694745bd4196",
-          "date": "2020-06-26T07:36:00-06:00",
-          "path": "/nix/store/yh4h2ibv6kq7lhsyn3jhp7y99v85y2nc-hts-nim",
-          "sha256": "17vi2dbrq5annq2mfpg5pkij29qywdyw0771jwzjy266fgnhrl4f",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "0.3.0",
         "value": {
           "url": "https://github.com/brentp/hts-nim",
           "rev": "f611fd86a335ccfd5321808eacf37ddac9546575",
           "date": "2020-01-06T09:38:53-07:00",
           "sha256": "1ai97jcpqr5aw69dwqsw8da7hsxsl3y7bdvwr3ld6c4kllrbsc27",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.8",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "c8aafad74b1b9bba01e1723c364b39c7b5ea226e",
-          "date": "2019-02-28T11:15:29-07:00",
-          "sha256": "0bqnpsvbxw5l3g4zhvj21x847czqfqkkhxnawbkdn509d3wkq9dd",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.7",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "6ebbe611810f0ceb170984a7a08287d9ee189de6",
-          "date": "2018-11-30T09:38:47-07:00",
-          "sha256": "11kspkh8iknxbrzwbf1v74f46izj283kmm3lczm4ryzfndav4qpn",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.5",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "5ece6ce5b7c0e32ec32d9fbef5969b1409573716",
-          "date": "2018-09-20T13:17:56-06:00",
-          "sha256": "1fma99rjqxgg9dihkd10hm1jjp5amsk5wsxnvq1lk4mcsjix5xqb",
           "fetchSubmodules": false
         }
       },
@@ -240,16 +210,6 @@
           "rev": "ea98f4cc44bff9f726c56c23d613e2dd47c37475",
           "date": "2019-08-17T10:28:41-06:00",
           "sha256": "0awpn05l5i58isyckyjag14d4npay6bcsjjldhrgd5q2l9px6mn2",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.2",
-        "value": {
-          "url": "https://github.com/brentp/hts-nim",
-          "rev": "af9cecf2a05379bb37ba509babf35eda5b9da388",
-          "date": "2018-07-23T11:41:24-06:00",
-          "sha256": "1q19rfv24rpkp4ixd2vdxd8z0jyl26wxsjvlg41icpnbr401sink",
           "fetchSubmodules": false
         }
       },
@@ -340,6 +300,46 @@
           "rev": "906b366e91dab0da54ce8940b8c55221fe787051",
           "date": "2019-04-22T09:38:40-06:00",
           "sha256": "0cdxx6n22bas2ivw5g444rrg8qb3i127h5n57gizi7q7fig01zdd",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.8",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "c8aafad74b1b9bba01e1723c364b39c7b5ea226e",
+          "date": "2019-02-28T11:15:29-07:00",
+          "sha256": "0bqnpsvbxw5l3g4zhvj21x847czqfqkkhxnawbkdn509d3wkq9dd",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.7",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "6ebbe611810f0ceb170984a7a08287d9ee189de6",
+          "date": "2018-11-30T09:38:47-07:00",
+          "sha256": "11kspkh8iknxbrzwbf1v74f46izj283kmm3lczm4ryzfndav4qpn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.5",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "5ece6ce5b7c0e32ec32d9fbef5969b1409573716",
+          "date": "2018-09-20T13:17:56-06:00",
+          "sha256": "1fma99rjqxgg9dihkd10hm1jjp5amsk5wsxnvq1lk4mcsjix5xqb",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.2",
+        "value": {
+          "url": "https://github.com/brentp/hts-nim",
+          "rev": "af9cecf2a05379bb37ba509babf35eda5b9da388",
+          "date": "2018-07-23T11:41:24-06:00",
+          "sha256": "1q19rfv24rpkp4ixd2vdxd8z0jyl26wxsjvlg41icpnbr401sink",
           "fetchSubmodules": false
         }
       },

--- a/packages/microasynchttpserver.json
+++ b/packages/microasynchttpserver.json
@@ -4,26 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.5",
-        "value": {
-          "url": "https://github.com/philip-wernersbach/microasynchttpserver",
-          "rev": "dd5884d717ecb5e94fc8e3b2a8c462e2e78e4c84",
-          "date": "2016-10-27T13:02:45-04:00",
-          "sha256": "1r6rgkz6s0hgzqpvhbvjmnwvzjmvwgz7447mid1binrwyc9np980",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/philip-wernersbach/microasynchttpserver",
-          "rev": "77a5badaf786fd627eb77757d1545e41fb1059ce",
-          "date": "2016-08-20T22:23:52-04:00",
-          "sha256": "0kp7kba6z5y3qsqpn5haa2bvmhf15hryvr5lvfa7mz6mglrkrypn",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.10.2",
         "value": {
           "url": "https://github.com/philip-wernersbach/microasynchttpserver",
@@ -50,6 +30,26 @@
           "rev": "7a461767f961536200c7232448d0446687e71a67",
           "date": "2016-11-28T00:28:04-05:00",
           "sha256": "11x1pw1bw5sry76s8dcz804jp8pcgq2fysjpp24psqhf7gc3fihg",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.5",
+        "value": {
+          "url": "https://github.com/philip-wernersbach/microasynchttpserver",
+          "rev": "dd5884d717ecb5e94fc8e3b2a8c462e2e78e4c84",
+          "date": "2016-10-27T13:02:45-04:00",
+          "sha256": "1r6rgkz6s0hgzqpvhbvjmnwvzjmvwgz7447mid1binrwyc9np980",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/philip-wernersbach/microasynchttpserver",
+          "rev": "77a5badaf786fd627eb77757d1545e41fb1059ce",
+          "date": "2016-08-20T22:23:52-04:00",
+          "sha256": "0kp7kba6z5y3qsqpn5haa2bvmhf15hryvr5lvfa7mz6mglrkrypn",
           "fetchSubmodules": false
         }
       }

--- a/packages/moustachu.json
+++ b/packages/moustachu.json
@@ -4,6 +4,86 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.14.0",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "f5d3a1e6454f6c0436b54503bd5f560c178aea2a",
+          "date": "2020-02-08T10:45:42-06:00",
+          "sha256": "16ij1igddmily9g1kbkmhv6kvmnzyhdy10ifidf32frkraypkdm3",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.13.0",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "3c1d066d14dd46e711b152002d2bbe3bb3c29f79",
+          "date": "2018-09-30T15:17:14-05:00",
+          "sha256": "15b0ild5p89m843x2mf2myfh7y674sv18nhl2bvwgd6fp0zrdpfy",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "29e8dd73b93d0690ae2804aced56a88b3d2fb5ac",
+          "date": "2018-07-19T21:00:53-05:00",
+          "sha256": "1j5byh9xzdmzbj8gi80vdrradhdirsxvbpzjhkw0fh5h2hc62di9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.1",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "1b00685bc81f5a532d3460622749016185abb120",
+          "date": "2017-08-12T22:11:35-04:00",
+          "sha256": "13mg2zc5zs1dizpa23arfviv4qci3ckw11d3n9x7a7ljkbj9d3f5",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.3",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "b89dbc5978b440bbab1e2580495d15ac68217b69",
+          "date": "2016-06-09T23:08:03-04:00",
+          "sha256": "1ib9sxj4j3gbxjrxa3vqqz479ylh571gxhqj5q70wi9rjgag8ziz",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.2",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "4b43ea82d8b9c535c12c7985b106535cbca10f15",
+          "date": "2016-06-06T20:49:34-04:00",
+          "sha256": "177xw6mix2xfy33qydbvpf773sfgsv0q1kxd9wn0ix7gkg5wm7jn",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "db9fc5b285db10f5b25727e2badb9f0b7a45a2e1",
+          "date": "2016-06-04T13:18:02-04:00",
+          "sha256": "144wms62f5ccd6nh1by1qqyqfafhk41lhh7ica5c1xlwdd19bg6h",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/fenekku/moustachu.git",
+          "rev": "c692555cc9a6bb43417e99dbcc73f85e6fe5412e",
+          "date": "2016-05-15T10:58:57-04:00",
+          "sha256": "1ighfxx94aagpbgw2adqsv1nnv5vmnh5mb89vvakjklcdmdmp4vj",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.1",
         "value": {
           "url": "https://github.com/fenekku/moustachu.git",
@@ -100,86 +180,6 @@
           "rev": "716117ab2ac94cd335ef03987e65c9313376d460",
           "date": "2014-11-23T15:48:10-05:00",
           "sha256": "0kdr0wcf5f5chsnrb9c0m9n7vvqgydhzqpbr6y0l681ymj9d1l7v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.14.0",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "f5d3a1e6454f6c0436b54503bd5f560c178aea2a",
-          "date": "2020-02-08T10:45:42-06:00",
-          "sha256": "16ij1igddmily9g1kbkmhv6kvmnzyhdy10ifidf32frkraypkdm3",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.13.0",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "3c1d066d14dd46e711b152002d2bbe3bb3c29f79",
-          "date": "2018-09-30T15:17:14-05:00",
-          "sha256": "15b0ild5p89m843x2mf2myfh7y674sv18nhl2bvwgd6fp0zrdpfy",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "29e8dd73b93d0690ae2804aced56a88b3d2fb5ac",
-          "date": "2018-07-19T21:00:53-05:00",
-          "sha256": "1j5byh9xzdmzbj8gi80vdrradhdirsxvbpzjhkw0fh5h2hc62di9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.1",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "1b00685bc81f5a532d3460622749016185abb120",
-          "date": "2017-08-12T22:11:35-04:00",
-          "sha256": "13mg2zc5zs1dizpa23arfviv4qci3ckw11d3n9x7a7ljkbj9d3f5",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.3",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "b89dbc5978b440bbab1e2580495d15ac68217b69",
-          "date": "2016-06-09T23:08:03-04:00",
-          "sha256": "1ib9sxj4j3gbxjrxa3vqqz479ylh571gxhqj5q70wi9rjgag8ziz",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.2",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "4b43ea82d8b9c535c12c7985b106535cbca10f15",
-          "date": "2016-06-06T20:49:34-04:00",
-          "sha256": "177xw6mix2xfy33qydbvpf773sfgsv0q1kxd9wn0ix7gkg5wm7jn",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "db9fc5b285db10f5b25727e2badb9f0b7a45a2e1",
-          "date": "2016-06-04T13:18:02-04:00",
-          "sha256": "144wms62f5ccd6nh1by1qqyqfafhk41lhh7ica5c1xlwdd19bg6h",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/fenekku/moustachu.git",
-          "rev": "c692555cc9a6bb43417e99dbcc73f85e6fe5412e",
-          "date": "2016-05-15T10:58:57-04:00",
-          "sha256": "1ighfxx94aagpbgw2adqsv1nnv5vmnh5mb89vvakjklcdmdmp4vj",
           "fetchSubmodules": false
         }
       }

--- a/packages/nasher.json
+++ b/packages/nasher.json
@@ -4,6 +4,234 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.13.0",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "af73e0d54997224bed24ba41e6fe3a9ce2ce48fb",
+          "date": "2020-11-07T23:14:34-06:00",
+          "path": "/nix/store/sm553m87ajv650r7h0l7vhqcdcw27gzq-nasher.nim",
+          "sha256": "1c3m2sn1xnnca06vwxli6br5lc6fvkxjfanvhjxj96chql9bqkjd",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.12.3",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "1e6f41ba473750bfeda6452cfeec92b668d8ff79",
+          "date": "2020-10-21T23:54:20-05:00",
+          "path": "/nix/store/q9kdkg4pz3cc7ranyvm47rzqcs959s09-nasher.nim",
+          "sha256": "0vighy01mbr0vdh6d9fly9hygqwgn3fdr8bbynr8mpzg1phhpnhr",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.12.2",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "6f5bd801724f1ffab51fcf2b205eeb023ba86a33",
+          "date": "2020-10-20T18:53:07-05:00",
+          "path": "/nix/store/szq7ghk52z6hhr9rkf33d78rb6g9mjrp-nasher.nim",
+          "sha256": "08sq63xv2mzakgj8d0yn0ak6igrbr1rrm0qb5h2y3d2iab8sn3rp",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.12.1",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "769a6ba9cc4bcc2c0ebd62cabb329a3e11e08b3b",
+          "date": "2020-10-20T18:21:13-05:00",
+          "path": "/nix/store/gx5wv9nv8rl7232zfxypqnm97caw36yr-nasher.nim",
+          "sha256": "1pw0cfi8afflpf72jpvfg7l372mgqqvp3b7b8h30f8fxvd0kqpdl",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "98717e8579799de0e8f97b74493f256be38388ae",
+          "date": "2020-10-20T13:49:50-05:00",
+          "path": "/nix/store/v2xpssbwsbq6kv9vhy3affam0lslvl25-nasher.nim",
+          "sha256": "0mhw0f5pagbb3g2bkpd1rl7pcv4wxp4q1y3fvrjdc085yss4hp31",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.9",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "24a403cea8ebab07f576368bb4a8c4e1e9cf2ded",
+          "date": "2020-09-29T10:06:58-05:00",
+          "path": "/nix/store/f69qa1h2l1ks5qn2pl9v45j11355zbpy-nasher.nim",
+          "sha256": "1yws6f93rrrvx8wv3n4m8xdapinyz5a6z2jp43s0ck38p2x7yai3",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.8",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "63fb6c1fa8e2f2f8feadaee4df074e369bfe131f",
+          "date": "2020-06-21T14:20:15-05:00",
+          "path": "/nix/store/spc9xcnkpkx8q233g61pv51zjq1041s4-nasher.nim",
+          "sha256": "1kk96b54lw3npwpw61d9q0i5bm1hvf0ggjqhfwn0apysb64xigyi",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.7",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "cab8636a1ae2512b40d76e8813b6012a9ead9d3a",
+          "date": "2020-06-05T08:21:33-05:00",
+          "path": "/nix/store/6vl2vdp27zzd4bhbg0i95n0mw7vj582i-nasher.nim",
+          "sha256": "1awn2c3wpg0ccbl53hglvfxind0bgwh57gd5a85xcb74vlrddi0b",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.6",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "b1c1dea8b562a51da3c6fa37136de3f0116e455e",
+          "date": "2020-05-31T12:38:30-05:00",
+          "path": "/nix/store/w7v2qy8mpghnr3lr1z7dcvamk6dlfqvd-nasher.nim",
+          "sha256": "0v9lrrfkdamr769ycbaxh3a2b66d5za2jnp6cj4nsda050j6nfj8",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.5",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "3b6a2e2095388f7b9286f48862b6ed1fcc5476de",
+          "date": "2020-05-20T17:49:46-05:00",
+          "path": "/nix/store/mg45h0g5alf4nsxnbazdcxdw60g4wlg5-nasher.nim",
+          "sha256": "1cs3hwf0xhaczw0qbwjy74gz4fbc6f48zwlp7svjym25gylcjwga",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.4",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "4f2e52ebef3262ff57223040f10cc65fb8ad38a2",
+          "date": "2020-05-16T12:11:15-05:00",
+          "path": "/nix/store/iw7q7x1w39jniljc5fyy9h5d0byrma5s-nasher.nim",
+          "sha256": "0gryh04a1arrs29pgqwjfppxihrv5fkhkkcf4icrhksjvm2z423m",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.3",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "28c0167bcc6206c7f8cfbccc6aae35d21526911f",
+          "date": "2020-05-15T19:35:57-05:00",
+          "path": "/nix/store/9mb3r7rhq92qc00zj2lhfbhpk474zk1y-nasher.nim",
+          "sha256": "035w2rbbvai08vv6cmn3lnki6n4ayjfcif9b6jsgcr968snsad7v",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.2",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "995dc6d049c1f140aacf584ab8c380dbeb2d886c",
+          "date": "2020-05-11T08:34:38-05:00",
+          "path": "/nix/store/9nkbgq5cgqy0y95999bmlq15m7zmv408-nasher.nim",
+          "sha256": "1zv08lb4im90dmdp4302l3flxwc6fxr8n51nd5yr4zlfl1dwrdyy",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.1",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "f177a55c96fe27f0b1d1cec6edb3ddfad2192665",
+          "date": "2020-05-04T10:52:17-05:00",
+          "path": "/nix/store/43sy2q41jqvs7igiy4zx4r34aqyaw077-nasher.nim",
+          "sha256": "0r9b3fyk0j05i159pr9zys4rbxzaxsads92snddi7q6l894p97pc",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "56fc5fe16fc77bf34abb3472ae8828944471d428",
+          "date": "2020-04-05T09:58:57-05:00",
+          "path": "/nix/store/f5nfcv08mlg3d5rdjz35hd5kh00s03mg-nasher.nim",
+          "sha256": "0nzw9chy8b8zhhxi3q0vcnxqawygsg5g6i3ivdlzrm729gp6h451",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.10.2",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "85d985386eb555674f45aa7d529793f09c6af65e",
+          "date": "2020-04-02T15:49:46-05:00",
+          "path": "/nix/store/7fnbiy7nkdma335avfgprbxn1w5v3bdp-nasher.nim",
+          "sha256": "12r67ql0b3dagp0kj3c3mxxvv2mywiz7cc46hdrbyj3jxfsz0a3z",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "43ebce7fcb55a507e95b1dc9630478b747f458a4",
+          "date": "2020-03-19T08:56:56-05:00",
+          "sha256": "1wn0yb0qvi4092l7br51skcf0d7wnmxk30fgp2zrj5ksw0smafmw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/squattingmonk/nasher.nim",
+          "rev": "224b71c6db9041cb1e3a39453eb2526978a6cdc1",
+          "date": "2020-03-17T09:49:38-05:00",
+          "sha256": "1ws9lhflzrf8ak8frljhkl38v4yv5mxqff2z0ksg33cr1wk670qp",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.6",
         "value": {
           "url": "https://github.com/squattingmonk/nasher.nim",
@@ -240,234 +468,6 @@
           "rev": "98bee1dd59288ee5c29515543fa6f2b2efa1ac27",
           "date": "2019-07-12T20:53:20-05:00",
           "sha256": "0sfk5l0k1dk4iga36nvrc42ckaynkhyd8b9zd7kjlj0vyc7z3p4v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.13.0",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "af73e0d54997224bed24ba41e6fe3a9ce2ce48fb",
-          "date": "2020-11-07T23:14:34-06:00",
-          "path": "/nix/store/sm553m87ajv650r7h0l7vhqcdcw27gzq-nasher.nim",
-          "sha256": "1c3m2sn1xnnca06vwxli6br5lc6fvkxjfanvhjxj96chql9bqkjd",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.12.3",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "1e6f41ba473750bfeda6452cfeec92b668d8ff79",
-          "date": "2020-10-21T23:54:20-05:00",
-          "path": "/nix/store/q9kdkg4pz3cc7ranyvm47rzqcs959s09-nasher.nim",
-          "sha256": "0vighy01mbr0vdh6d9fly9hygqwgn3fdr8bbynr8mpzg1phhpnhr",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.12.2",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "6f5bd801724f1ffab51fcf2b205eeb023ba86a33",
-          "date": "2020-10-20T18:53:07-05:00",
-          "path": "/nix/store/szq7ghk52z6hhr9rkf33d78rb6g9mjrp-nasher.nim",
-          "sha256": "08sq63xv2mzakgj8d0yn0ak6igrbr1rrm0qb5h2y3d2iab8sn3rp",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.12.1",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "769a6ba9cc4bcc2c0ebd62cabb329a3e11e08b3b",
-          "date": "2020-10-20T18:21:13-05:00",
-          "path": "/nix/store/gx5wv9nv8rl7232zfxypqnm97caw36yr-nasher.nim",
-          "sha256": "1pw0cfi8afflpf72jpvfg7l372mgqqvp3b7b8h30f8fxvd0kqpdl",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "98717e8579799de0e8f97b74493f256be38388ae",
-          "date": "2020-10-20T13:49:50-05:00",
-          "path": "/nix/store/v2xpssbwsbq6kv9vhy3affam0lslvl25-nasher.nim",
-          "sha256": "0mhw0f5pagbb3g2bkpd1rl7pcv4wxp4q1y3fvrjdc085yss4hp31",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.9",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "24a403cea8ebab07f576368bb4a8c4e1e9cf2ded",
-          "date": "2020-09-29T10:06:58-05:00",
-          "path": "/nix/store/f69qa1h2l1ks5qn2pl9v45j11355zbpy-nasher.nim",
-          "sha256": "1yws6f93rrrvx8wv3n4m8xdapinyz5a6z2jp43s0ck38p2x7yai3",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.8",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "63fb6c1fa8e2f2f8feadaee4df074e369bfe131f",
-          "date": "2020-06-21T14:20:15-05:00",
-          "path": "/nix/store/spc9xcnkpkx8q233g61pv51zjq1041s4-nasher.nim",
-          "sha256": "1kk96b54lw3npwpw61d9q0i5bm1hvf0ggjqhfwn0apysb64xigyi",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.7",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "cab8636a1ae2512b40d76e8813b6012a9ead9d3a",
-          "date": "2020-06-05T08:21:33-05:00",
-          "path": "/nix/store/6vl2vdp27zzd4bhbg0i95n0mw7vj582i-nasher.nim",
-          "sha256": "1awn2c3wpg0ccbl53hglvfxind0bgwh57gd5a85xcb74vlrddi0b",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.6",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "b1c1dea8b562a51da3c6fa37136de3f0116e455e",
-          "date": "2020-05-31T12:38:30-05:00",
-          "path": "/nix/store/w7v2qy8mpghnr3lr1z7dcvamk6dlfqvd-nasher.nim",
-          "sha256": "0v9lrrfkdamr769ycbaxh3a2b66d5za2jnp6cj4nsda050j6nfj8",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.5",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "3b6a2e2095388f7b9286f48862b6ed1fcc5476de",
-          "date": "2020-05-20T17:49:46-05:00",
-          "path": "/nix/store/mg45h0g5alf4nsxnbazdcxdw60g4wlg5-nasher.nim",
-          "sha256": "1cs3hwf0xhaczw0qbwjy74gz4fbc6f48zwlp7svjym25gylcjwga",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.4",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "4f2e52ebef3262ff57223040f10cc65fb8ad38a2",
-          "date": "2020-05-16T12:11:15-05:00",
-          "path": "/nix/store/iw7q7x1w39jniljc5fyy9h5d0byrma5s-nasher.nim",
-          "sha256": "0gryh04a1arrs29pgqwjfppxihrv5fkhkkcf4icrhksjvm2z423m",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.3",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "28c0167bcc6206c7f8cfbccc6aae35d21526911f",
-          "date": "2020-05-15T19:35:57-05:00",
-          "path": "/nix/store/9mb3r7rhq92qc00zj2lhfbhpk474zk1y-nasher.nim",
-          "sha256": "035w2rbbvai08vv6cmn3lnki6n4ayjfcif9b6jsgcr968snsad7v",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.2",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "995dc6d049c1f140aacf584ab8c380dbeb2d886c",
-          "date": "2020-05-11T08:34:38-05:00",
-          "path": "/nix/store/9nkbgq5cgqy0y95999bmlq15m7zmv408-nasher.nim",
-          "sha256": "1zv08lb4im90dmdp4302l3flxwc6fxr8n51nd5yr4zlfl1dwrdyy",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.1",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "f177a55c96fe27f0b1d1cec6edb3ddfad2192665",
-          "date": "2020-05-04T10:52:17-05:00",
-          "path": "/nix/store/43sy2q41jqvs7igiy4zx4r34aqyaw077-nasher.nim",
-          "sha256": "0r9b3fyk0j05i159pr9zys4rbxzaxsads92snddi7q6l894p97pc",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "56fc5fe16fc77bf34abb3472ae8828944471d428",
-          "date": "2020-04-05T09:58:57-05:00",
-          "path": "/nix/store/f5nfcv08mlg3d5rdjz35hd5kh00s03mg-nasher.nim",
-          "sha256": "0nzw9chy8b8zhhxi3q0vcnxqawygsg5g6i3ivdlzrm729gp6h451",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.10.2",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "85d985386eb555674f45aa7d529793f09c6af65e",
-          "date": "2020-04-02T15:49:46-05:00",
-          "path": "/nix/store/7fnbiy7nkdma335avfgprbxn1w5v3bdp-nasher.nim",
-          "sha256": "12r67ql0b3dagp0kj3c3mxxvv2mywiz7cc46hdrbyj3jxfsz0a3z",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "43ebce7fcb55a507e95b1dc9630478b747f458a4",
-          "date": "2020-03-19T08:56:56-05:00",
-          "sha256": "1wn0yb0qvi4092l7br51skcf0d7wnmxk30fgp2zrj5ksw0smafmw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/squattingmonk/nasher.nim",
-          "rev": "224b71c6db9041cb1e3a39453eb2526978a6cdc1",
-          "date": "2020-03-17T09:49:38-05:00",
-          "sha256": "1ws9lhflzrf8ak8frljhkl38v4yv5mxqff2z0ksg33cr1wk670qp",
           "fetchSubmodules": false
         }
       },

--- a/packages/neverwinter.json
+++ b/packages/neverwinter.json
@@ -56,6 +56,32 @@
         }
       },
       {
+        "name": "1.2.10-1.2.0",
+        "value": {
+          "url": "https://github.com/niv/neverwinter.nim",
+          "rev": "cef8b8a7e75c9a4f829a749f0239b497a51a7e93",
+          "date": "2020-05-07T13:11:13+02:00",
+          "path": "/nix/store/hf4vlfk90jqzzwpr3nylwjnblml745xk-neverwinter.nim",
+          "sha256": "104l824mwn5pfwmv58q3h2h5rmqha6rpfj8jins442l02v7dbriw",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.2.10",
+        "value": {
+          "url": "https://github.com/niv/neverwinter.nim",
+          "rev": "cef8b8a7e75c9a4f829a749f0239b497a51a7e93",
+          "date": "2020-05-07T13:11:13+02:00",
+          "path": "/nix/store/hf4vlfk90jqzzwpr3nylwjnblml745xk-neverwinter.nim",
+          "sha256": "104l824mwn5pfwmv58q3h2h5rmqha6rpfj8jins442l02v7dbriw",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "1.2.9",
         "value": {
           "url": "https://github.com/niv/neverwinter.nim",
@@ -123,32 +149,6 @@
           "date": "2019-02-19T11:52:44+01:00",
           "sha256": "0kiwbsalx4c3blwfb305pmbw60ffpn3pgyrshndvvds60ha5070f",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.2.10-1.2.0",
-        "value": {
-          "url": "https://github.com/niv/neverwinter.nim",
-          "rev": "cef8b8a7e75c9a4f829a749f0239b497a51a7e93",
-          "date": "2020-05-07T13:11:13+02:00",
-          "path": "/nix/store/hf4vlfk90jqzzwpr3nylwjnblml745xk-neverwinter.nim",
-          "sha256": "104l824mwn5pfwmv58q3h2h5rmqha6rpfj8jins442l02v7dbriw",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.2.10",
-        "value": {
-          "url": "https://github.com/niv/neverwinter.nim",
-          "rev": "cef8b8a7e75c9a4f829a749f0239b497a51a7e93",
-          "date": "2020-05-07T13:11:13+02:00",
-          "path": "/nix/store/hf4vlfk90jqzzwpr3nylwjnblml745xk-neverwinter.nim",
-          "sha256": "104l824mwn5pfwmv58q3h2h5rmqha6rpfj8jins442l02v7dbriw",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/nimble.json
+++ b/packages/nimble.json
@@ -4,186 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "af1c1d73c32b6e9fe7a8aecf3768d9f482b18180",
-          "date": "2018-09-19T23:53:27+01:00",
-          "sha256": "16aiav360p3fj7r044cb2hq59szx7igrx60r782dfr4cfhyc1p4s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.8",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "5b82e06d0010126b698280fc6196286e3f5660b7",
-          "date": "2017-09-03T18:26:17+01:00",
-          "sha256": "1j6g3wfp4ksz9g2yz7yzx04khv02sfacid03k4k9g6f3rvzv089c",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.6",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "5adfe3015542907802ce2d2c2ae8320bd980f6e3",
-          "date": "2017-05-05T16:47:17+01:00",
-          "sha256": "05qm6hiwkfww02vpl6vmlgxp5qam5f2i161fa56k2xljr3ymx5g2",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.4",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "0a280aa6dd0c7566fbf70775b69f33b100f2d1de",
-          "date": "2017-01-29T21:31:31+01:00",
-          "sha256": "156d91q8pv11a30cr761lmyzz2iny1nsk05gq36wbrkfaprx5x07",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.2",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "690fcf04a378da0eb3f4c164077bcfccc6cf2b6d",
-          "date": "2017-01-08T18:41:00+01:00",
-          "sha256": "075mvh34idfm8niw6w4h75gzndjxngy6161azqkyjxgz9383lnmg",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.10",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "6a2da5627c029460f6f714a44f5275762102fa4b",
-          "date": "2018-02-23T23:15:12+00:00",
-          "sha256": "1i641i7rgsd985667ziyn83gqda6xf2zckzd8bz5fd3cn9aiij4l",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "8a3c661b9898d94d81028ff8ed5fae2d5e29f882",
-          "date": "2017-01-05T21:28:52+00:00",
-          "sha256": "1i96q5k6mrg11vjkbrsca6y1aa8sdrc76421ph3g3hiik1fp33bp",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.8",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "e3682c96b3580739fb017c756c1d64be3d3208ea",
-          "date": "2016-09-29T21:35:52+02:00",
-          "sha256": "12znxzj1j5fflw2mkkrns9n7qg6sf207652zrdyf7h2jdyzzb73x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.6",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "f0dd4a1efc747fabe9526ac2b6a4200e2c3ca8fe",
-          "date": "2016-09-26T19:11:36+02:00",
-          "sha256": "1pxr5pr8r7jyszvjgk28gyck5i1sdd18ybwdrlpb3gd2m7n79w39",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.4",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "cc2c606fbe18d68af3aa42d44a256a9937ef9685",
-          "date": "2016-06-06T22:04:49+01:00",
-          "sha256": "1l477f1zlqpc738jg47pz599cwjasgy9jqdsplj3ywd12xfqpc96",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.2",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "83b1292d232b8f488d2ef74b548db19f202f6773",
-          "date": "2016-02-11T16:24:13+00:00",
-          "sha256": "0j9b519cv91xwn6k0alynakh7grbq4m6yy5bdwdrqmc7lag35r0i",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.10",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "1be5c052ae3e95ef8fdc745617e1f23b88ad839a",
-          "date": "2016-10-09T15:20:31+02:00",
-          "sha256": "1bcv8chir73nn6x7q8n3sw2scf3m0x2w9gkkzx162ryivza1nm1r",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "80a418e68063eeb32f311341573567bf545dc8d9",
-          "date": "2015-12-31T00:30:31+00:00",
-          "sha256": "1719m77ymp3rxm54ag7rzall8rk4y8n4qplwha414f4gsv5kdfa7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.4",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "ffbd5f5b3ec85a68e179233275ff4ef54cc280a3",
-          "date": "2015-10-13T10:17:02+02:00",
-          "sha256": "0c6slry22ppxcviw5x4hvg5vrx7baqc75ri6in94pmhr924b8anx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.2",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "7524cd17984465ba2c1cc119a9e33bc916516471",
-          "date": "2015-06-19T19:45:40+01:00",
-          "sha256": "1qv3px5zvp4j9vx1lbhzwybqf4a90ikmqd7i9pn0mxjbs8r0lz4i",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "875786d34fc4e342eb2fdc849d6d84718c615e84",
-          "date": "2014-12-26T01:32:10+00:00",
-          "sha256": "17islf0g2nmpg4008jf24cs78q4p3lq3d4820m8qvln9q84pdii2",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "05ac7d5bcd2edb95dda8cdd9d4213433976d72af",
-          "date": "2014-06-24T00:32:41+01:00",
-          "sha256": "1vlrxrqmjrq3ln53rj9xznr2j4n4m5xj0csqr7yhs1k53lv4g94g",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2",
-        "value": {
-          "url": "https://github.com/nim-lang/nimble",
-          "rev": "64164e93cdf31d853cffa011b3873127353f2f98",
-          "date": "2013-12-30T18:35:38+00:00",
-          "sha256": "1809jmg3kqqz7203jq6cc1xn7gknrls9ajpr2savaf3zkznln19y",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.12.0",
         "value": {
           "url": "https://github.com/nim-lang/nimble",
@@ -249,6 +69,186 @@
           "rev": "06b9b494496a622cd444e992142af4cdbcfca416",
           "date": "2019-05-27T19:29:19+01:00",
           "sha256": "1q42d6agy53m260vkmdapg0qhf825snxd1yhih3jlnjz1yzcrlz2",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "af1c1d73c32b6e9fe7a8aecf3768d9f482b18180",
+          "date": "2018-09-19T23:53:27+01:00",
+          "sha256": "16aiav360p3fj7r044cb2hq59szx7igrx60r782dfr4cfhyc1p4s",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.10",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "6a2da5627c029460f6f714a44f5275762102fa4b",
+          "date": "2018-02-23T23:15:12+00:00",
+          "sha256": "1i641i7rgsd985667ziyn83gqda6xf2zckzd8bz5fd3cn9aiij4l",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.8",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "5b82e06d0010126b698280fc6196286e3f5660b7",
+          "date": "2017-09-03T18:26:17+01:00",
+          "sha256": "1j6g3wfp4ksz9g2yz7yzx04khv02sfacid03k4k9g6f3rvzv089c",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.6",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "5adfe3015542907802ce2d2c2ae8320bd980f6e3",
+          "date": "2017-05-05T16:47:17+01:00",
+          "sha256": "05qm6hiwkfww02vpl6vmlgxp5qam5f2i161fa56k2xljr3ymx5g2",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.4",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "0a280aa6dd0c7566fbf70775b69f33b100f2d1de",
+          "date": "2017-01-29T21:31:31+01:00",
+          "sha256": "156d91q8pv11a30cr761lmyzz2iny1nsk05gq36wbrkfaprx5x07",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.2",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "690fcf04a378da0eb3f4c164077bcfccc6cf2b6d",
+          "date": "2017-01-08T18:41:00+01:00",
+          "sha256": "075mvh34idfm8niw6w4h75gzndjxngy6161azqkyjxgz9383lnmg",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "8a3c661b9898d94d81028ff8ed5fae2d5e29f882",
+          "date": "2017-01-05T21:28:52+00:00",
+          "sha256": "1i96q5k6mrg11vjkbrsca6y1aa8sdrc76421ph3g3hiik1fp33bp",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.10",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "1be5c052ae3e95ef8fdc745617e1f23b88ad839a",
+          "date": "2016-10-09T15:20:31+02:00",
+          "sha256": "1bcv8chir73nn6x7q8n3sw2scf3m0x2w9gkkzx162ryivza1nm1r",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.8",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "e3682c96b3580739fb017c756c1d64be3d3208ea",
+          "date": "2016-09-29T21:35:52+02:00",
+          "sha256": "12znxzj1j5fflw2mkkrns9n7qg6sf207652zrdyf7h2jdyzzb73x",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.6",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "f0dd4a1efc747fabe9526ac2b6a4200e2c3ca8fe",
+          "date": "2016-09-26T19:11:36+02:00",
+          "sha256": "1pxr5pr8r7jyszvjgk28gyck5i1sdd18ybwdrlpb3gd2m7n79w39",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.4",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "cc2c606fbe18d68af3aa42d44a256a9937ef9685",
+          "date": "2016-06-06T22:04:49+01:00",
+          "sha256": "1l477f1zlqpc738jg47pz599cwjasgy9jqdsplj3ywd12xfqpc96",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.2",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "83b1292d232b8f488d2ef74b548db19f202f6773",
+          "date": "2016-02-11T16:24:13+00:00",
+          "sha256": "0j9b519cv91xwn6k0alynakh7grbq4m6yy5bdwdrqmc7lag35r0i",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "80a418e68063eeb32f311341573567bf545dc8d9",
+          "date": "2015-12-31T00:30:31+00:00",
+          "sha256": "1719m77ymp3rxm54ag7rzall8rk4y8n4qplwha414f4gsv5kdfa7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.4",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "ffbd5f5b3ec85a68e179233275ff4ef54cc280a3",
+          "date": "2015-10-13T10:17:02+02:00",
+          "sha256": "0c6slry22ppxcviw5x4hvg5vrx7baqc75ri6in94pmhr924b8anx",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.2",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "7524cd17984465ba2c1cc119a9e33bc916516471",
+          "date": "2015-06-19T19:45:40+01:00",
+          "sha256": "1qv3px5zvp4j9vx1lbhzwybqf4a90ikmqd7i9pn0mxjbs8r0lz4i",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "875786d34fc4e342eb2fdc849d6d84718c615e84",
+          "date": "2014-12-26T01:32:10+00:00",
+          "sha256": "17islf0g2nmpg4008jf24cs78q4p3lq3d4820m8qvln9q84pdii2",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "05ac7d5bcd2edb95dda8cdd9d4213433976d72af",
+          "date": "2014-06-24T00:32:41+01:00",
+          "sha256": "1vlrxrqmjrq3ln53rj9xznr2j4n4m5xj0csqr7yhs1k53lv4g94g",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2",
+        "value": {
+          "url": "https://github.com/nim-lang/nimble",
+          "rev": "64164e93cdf31d853cffa011b3873127353f2f98",
+          "date": "2013-12-30T18:35:38+00:00",
+          "sha256": "1809jmg3kqqz7203jq6cc1xn7gknrls9ajpr2savaf3zkznln19y",
           "fetchSubmodules": false
         }
       }

--- a/packages/nimhdf5.json
+++ b/packages/nimhdf5.json
@@ -4,6 +4,45 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.3.12",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "a36691e230c51d1bdd7255867fbe60005554ba39",
+          "date": "2020-11-30T18:59:10+01:00",
+          "path": "/nix/store/s2vixldxy8sy0jdrivxa4sv4h2612kvg-nimhdf5",
+          "sha256": "1d3i8fm8c0hyb1szs14rr70rf16d9ghlpyi0nbnyzi8hfjhdh4q1",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.11",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "472c2c358dca58b14f2382830c3b3853a50f8ada",
+          "date": "2020-11-26T20:54:16+01:00",
+          "path": "/nix/store/1ilvf6k92q1h5ka1fnz3rgnd74nwyr07-nimhdf5",
+          "sha256": "14f8hn4rkl5mizvkqxs3paldjvwpq80266b3077y68kiz3nnj57g",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.10",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "5f0e467674533290539d6066328db7efd90df37e",
+          "date": "2020-05-05T12:19:51+02:00",
+          "path": "/nix/store/2w6la5czbg2k9zzfza2a79ymz25g6zzi-nimhdf5",
+          "sha256": "15xj7lcryic9cpp431vk77vx9kx1skas5ckh5darygvn11fha2zf",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.3.9",
         "value": {
           "url": "https://github.com/Vindaar/nimhdf5",
@@ -70,45 +109,6 @@
         }
       },
       {
-        "name": "0.3.12",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "a36691e230c51d1bdd7255867fbe60005554ba39",
-          "date": "2020-11-30T18:59:10+01:00",
-          "path": "/nix/store/s2vixldxy8sy0jdrivxa4sv4h2612kvg-nimhdf5",
-          "sha256": "1d3i8fm8c0hyb1szs14rr70rf16d9ghlpyi0nbnyzi8hfjhdh4q1",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.11",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "472c2c358dca58b14f2382830c3b3853a50f8ada",
-          "date": "2020-11-26T20:54:16+01:00",
-          "path": "/nix/store/1ilvf6k92q1h5ka1fnz3rgnd74nwyr07-nimhdf5",
-          "sha256": "14f8hn4rkl5mizvkqxs3paldjvwpq80266b3077y68kiz3nnj57g",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.10",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "5f0e467674533290539d6066328db7efd90df37e",
-          "date": "2020-05-05T12:19:51+02:00",
-          "path": "/nix/store/2w6la5czbg2k9zzfza2a79ymz25g6zzi-nimhdf5",
-          "sha256": "15xj7lcryic9cpp431vk77vx9kx1skas5ckh5darygvn11fha2zf",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "0.3.1",
         "value": {
           "url": "https://github.com/Vindaar/nimhdf5",
@@ -125,46 +125,6 @@
           "rev": "ed0340c8083926b6ef84c64f184df07d12a234f1",
           "date": "2019-11-17T19:48:49+01:00",
           "sha256": "1s4mnxs0dxxiazdky19llldw2p1pb8jm3xrspvg1b1xpdv37kywz",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.9",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "eda05eeb563b27e85f890fe1fbb8fc318dcd6d02",
-          "date": "2018-07-05T13:57:18+02:00",
-          "sha256": "0s6pnzzhrr1qzsjvmajcw8r4qpg6vcsgf624dkdsv156sa8bslx9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.8",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "63ceed1facebf6f5d3211cbf5879f4e95f3bccfd",
-          "date": "2018-03-26T17:05:53+02:00",
-          "sha256": "0ns3y4ihik44dwyx1q7v6j80qrig49qlqjn7231a4hgvybcssvpz",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.7",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "39e5e86dabbb8f4f39356f7e5d7d16113aae9a9a",
-          "date": "2018-03-18T17:08:43+01:00",
-          "sha256": "1ikj2blh9qlxgblgn34wgw05i1pfmjhichvi4qxi7gygz285kw15",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.6",
-        "value": {
-          "url": "https://github.com/Vindaar/nimhdf5",
-          "rev": "72570b2ad496784b166788a66b668bbd9c8012b2",
-          "date": "2018-02-23T15:30:07+01:00",
-          "sha256": "08n5nyy3lshqak5zz0n2ybgwhccb2h19hshv7088rpjibijsm82y",
           "fetchSubmodules": false
         }
       },
@@ -225,6 +185,46 @@
           "rev": "dfd13b97a819368ad3eee31824b430b86f99c35b",
           "date": "2018-07-22T17:22:42+02:00",
           "sha256": "1lzzpqniyy8snab8nz3kl71lkb9arcvzmfh7mqqw9pg4jw0r9zz2",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.9",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "eda05eeb563b27e85f890fe1fbb8fc318dcd6d02",
+          "date": "2018-07-05T13:57:18+02:00",
+          "sha256": "0s6pnzzhrr1qzsjvmajcw8r4qpg6vcsgf624dkdsv156sa8bslx9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.8",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "63ceed1facebf6f5d3211cbf5879f4e95f3bccfd",
+          "date": "2018-03-26T17:05:53+02:00",
+          "sha256": "0ns3y4ihik44dwyx1q7v6j80qrig49qlqjn7231a4hgvybcssvpz",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.7",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "39e5e86dabbb8f4f39356f7e5d7d16113aae9a9a",
+          "date": "2018-03-18T17:08:43+01:00",
+          "sha256": "1ikj2blh9qlxgblgn34wgw05i1pfmjhichvi4qxi7gygz285kw15",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.6",
+        "value": {
+          "url": "https://github.com/Vindaar/nimhdf5",
+          "rev": "72570b2ad496784b166788a66b668bbd9c8012b2",
+          "date": "2018-02-23T15:30:07+01:00",
+          "sha256": "08n5nyy3lshqak5zz0n2ybgwhccb2h19hshv7088rpjibijsm82y",
           "fetchSubmodules": false
         }
       }

--- a/packages/nimterop.json
+++ b/packages/nimterop.json
@@ -4,6 +4,58 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.6.13",
+        "value": {
+          "url": "https://github.com/genotrance/nimterop",
+          "rev": "f7cee5c983650336f93fde5d4fea087863ac0e5e",
+          "date": "2020-10-15T08:48:57-05:00",
+          "path": "/nix/store/w28d2wi5818s4dxdcf8rq549fn3p5c5q-nimterop",
+          "sha256": "1fvqjw7rwgg5f5b09jvc8hxp6304ihqr9pf355p6jr6lg9rs5r4q",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.6.12",
+        "value": {
+          "url": "https://github.com/genotrance/nimterop",
+          "rev": "0c2ca16f7ad9b1798f1c28ca0a3268d98e845a8d",
+          "date": "2020-10-05T21:25:35-05:00",
+          "path": "/nix/store/ifs96mf54k1xca2gkgn5pq1nhx7yprbs-nimterop",
+          "sha256": "0dns05qx44wrk1278al0as2l79q9c379bgz5ppva5xrcgrc6nk20",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.6.11",
+        "value": {
+          "url": "https://github.com/genotrance/nimterop",
+          "rev": "674d842415ef68979f6407cb31b08f179238b189",
+          "date": "2020-09-01T14:09:54-05:00",
+          "path": "/nix/store/9n1mfmkqyzh5qvdrmky2phr9crgar8ng-nimterop",
+          "sha256": "1n6x8n2iydck13hag4k1kws6q4cicz0vvdrwvyk0wzq0x15v41pp",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.6.10",
+        "value": {
+          "url": "https://github.com/genotrance/nimterop",
+          "rev": "f2139d53750c673208a3895e6c2b318e83ab7bf6",
+          "date": "2020-08-28T17:19:31-05:00",
+          "path": "/nix/store/5ff440wjiw4wxhd0khdb3j95ws8ag0vf-nimterop",
+          "sha256": "0n12c6sqb699787smxhmp58kicvb4ajixlaagv06i4sil6kwb0b9",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.6.9",
         "value": {
           "url": "https://github.com/genotrance/nimterop",
@@ -102,58 +154,6 @@
           "date": "2020-07-04T00:49:46-05:00",
           "path": "/nix/store/vx763x4hdq2d481nz2dvsr6n232m5zdi-nimterop",
           "sha256": "1wayznckivb47xinqg5giqchkhkzylvmp5n8ihm7yfk58aqd9sk0",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.6.13",
-        "value": {
-          "url": "https://github.com/genotrance/nimterop",
-          "rev": "f7cee5c983650336f93fde5d4fea087863ac0e5e",
-          "date": "2020-10-15T08:48:57-05:00",
-          "path": "/nix/store/w28d2wi5818s4dxdcf8rq549fn3p5c5q-nimterop",
-          "sha256": "1fvqjw7rwgg5f5b09jvc8hxp6304ihqr9pf355p6jr6lg9rs5r4q",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.6.12",
-        "value": {
-          "url": "https://github.com/genotrance/nimterop",
-          "rev": "0c2ca16f7ad9b1798f1c28ca0a3268d98e845a8d",
-          "date": "2020-10-05T21:25:35-05:00",
-          "path": "/nix/store/ifs96mf54k1xca2gkgn5pq1nhx7yprbs-nimterop",
-          "sha256": "0dns05qx44wrk1278al0as2l79q9c379bgz5ppva5xrcgrc6nk20",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.6.11",
-        "value": {
-          "url": "https://github.com/genotrance/nimterop",
-          "rev": "674d842415ef68979f6407cb31b08f179238b189",
-          "date": "2020-09-01T14:09:54-05:00",
-          "path": "/nix/store/9n1mfmkqyzh5qvdrmky2phr9crgar8ng-nimterop",
-          "sha256": "1n6x8n2iydck13hag4k1kws6q4cicz0vvdrwvyk0wzq0x15v41pp",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.6.10",
-        "value": {
-          "url": "https://github.com/genotrance/nimterop",
-          "rev": "f2139d53750c673208a3895e6c2b318e83ab7bf6",
-          "date": "2020-08-28T17:19:31-05:00",
-          "path": "/nix/store/5ff440wjiw4wxhd0khdb3j95ws8ag0vf-nimterop",
-          "sha256": "0n12c6sqb699787smxhmp58kicvb4ajixlaagv06i4sil6kwb0b9",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/packages/nimwc.json
+++ b/packages/nimwc.json
@@ -117,6 +117,26 @@
         }
       },
       {
+        "name": "4.0.11",
+        "value": {
+          "url": "https://github.com/ThomasTJdev/nim_websitecreator",
+          "rev": "6f109cd9f2e4c991ebc55ecb897734cd3a276711",
+          "date": "2018-12-08T10:28:51+01:00",
+          "sha256": "1z81ynzk8842vk49im58pc85vclagq8162mq5fhahqwpama1ql2p",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "4.0.10",
+        "value": {
+          "url": "https://github.com/ThomasTJdev/nim_websitecreator",
+          "rev": "3443e320f21f84c01f6cad0e63fa2e82209d1e77",
+          "date": "2018-12-08T09:48:38+01:00",
+          "sha256": "1vkxbb5g3fsjslrxs1s8ysrcnsk4ihsfnh6af3q6cwsagwag11l0",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "4.0.9",
         "value": {
           "url": "https://github.com/ThomasTJdev/nim_websitecreator",
@@ -183,26 +203,6 @@
           "rev": "56dc9565afc086571259e51b2a87be8605793233",
           "date": "2018-10-07T16:57:04+02:00",
           "sha256": "0am7irxa9936q31wy7vga9b17qx4wr9ckgfs98spvbzkqjjxmp57",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "4.0.11",
-        "value": {
-          "url": "https://github.com/ThomasTJdev/nim_websitecreator",
-          "rev": "6f109cd9f2e4c991ebc55ecb897734cd3a276711",
-          "date": "2018-12-08T10:28:51+01:00",
-          "sha256": "1z81ynzk8842vk49im58pc85vclagq8162mq5fhahqwpama1ql2p",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "4.0.10",
-        "value": {
-          "url": "https://github.com/ThomasTJdev/nim_websitecreator",
-          "rev": "3443e320f21f84c01f6cad0e63fa2e82209d1e77",
-          "date": "2018-12-08T09:48:38+01:00",
-          "sha256": "1vkxbb5g3fsjslrxs1s8ysrcnsk4ihsfnh6af3q6cwsagwag11l0",
           "fetchSubmodules": false
         }
       },

--- a/packages/norm.json
+++ b/packages/norm.json
@@ -190,86 +190,6 @@
         }
       },
       {
-        "name": "1.0.9",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "1228442aa292286e5935410a00392f7318889a05",
-          "date": "2019-05-08T12:09:16+04:00",
-          "sha256": "0x0jf74mb9f423igcnvr5iw3wq0pr5jz3qwvrxwf4q1w3p4yp68h",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.8",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "7d779e1dc0f7a3f7c60120c5fabb7491371e9181",
-          "date": "2019-04-30T14:28:31+04:00",
-          "sha256": "1dm4h26dilhq356m3g629m1b8hr7d9gvg9cm6pww3yv823ijajr7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.7",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "24bcc084fe998b7e52a552509936ae52a2e24e94",
-          "date": "2019-03-21T12:27:22+03:00",
-          "sha256": "12y9zwimfb3d50w1w3msiszy6ahwgx9nxfzq0ccmvlf56mis867m",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.6",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "ffc6a5559f76635525e0baedbfdb1927f80fc5da",
-          "date": "2019-03-21T11:52:50+03:00",
-          "sha256": "1i0hsy70n9xk6aiapifkq0qicnryrfmxfzrh6v96927f4yjfa1lp",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.5",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "2deaacaafab0e6b9a7d1d7af0eb8cceed0acc090",
-          "date": "2019-03-18T15:40:06+03:00",
-          "sha256": "14j15kqfbyx91j8h8gb4cw2ki3mqqd7damnhmb6nym9vp6sil7zc",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.4",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "c20d88b9cc790a2735c91e5db02085a5f1304237",
-          "date": "2019-03-03T22:46:34+04:00",
-          "sha256": "0pr68xcd2by5ld8rmrj5by677h4a4amjl358hp572d5jyk2bd5zz",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.3",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "cff3e2aad5cd4f7a11e62876f123c86743397d6f",
-          "date": "2019-03-02T10:17:41+04:00",
-          "sha256": "0pw7w2vy7hh62d6arpbib4vfx2zrim1gb8frdrwwc8rxppcb2l9p",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.2",
-        "value": {
-          "url": "https://github.com/moigagoo/norm",
-          "rev": "68b4d21a9f517a96a6345cb3a3863b783a046d4e",
-          "date": "2019-03-01T20:21:03+04:00",
-          "sha256": "16iwsnyn7cy48nvsamfzj7fbxzvk7w2q6vx1n33sl6iw32v2p31l",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "1.0.17",
         "value": {
           "url": "https://github.com/moigagoo/norm",
@@ -346,6 +266,86 @@
           "rev": "9da9256d0b8280e3ed5eba67195771f17aa7eeb7",
           "date": "2019-06-06T23:24:36+04:00",
           "sha256": "1491nk90g74pjxmrfa6pqfqqrz2yzf1wwzli7xj7nksdzvh38bkj",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.9",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "1228442aa292286e5935410a00392f7318889a05",
+          "date": "2019-05-08T12:09:16+04:00",
+          "sha256": "0x0jf74mb9f423igcnvr5iw3wq0pr5jz3qwvrxwf4q1w3p4yp68h",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.8",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "7d779e1dc0f7a3f7c60120c5fabb7491371e9181",
+          "date": "2019-04-30T14:28:31+04:00",
+          "sha256": "1dm4h26dilhq356m3g629m1b8hr7d9gvg9cm6pww3yv823ijajr7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.7",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "24bcc084fe998b7e52a552509936ae52a2e24e94",
+          "date": "2019-03-21T12:27:22+03:00",
+          "sha256": "12y9zwimfb3d50w1w3msiszy6ahwgx9nxfzq0ccmvlf56mis867m",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.6",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "ffc6a5559f76635525e0baedbfdb1927f80fc5da",
+          "date": "2019-03-21T11:52:50+03:00",
+          "sha256": "1i0hsy70n9xk6aiapifkq0qicnryrfmxfzrh6v96927f4yjfa1lp",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.5",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "2deaacaafab0e6b9a7d1d7af0eb8cceed0acc090",
+          "date": "2019-03-18T15:40:06+03:00",
+          "sha256": "14j15kqfbyx91j8h8gb4cw2ki3mqqd7damnhmb6nym9vp6sil7zc",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.4",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "c20d88b9cc790a2735c91e5db02085a5f1304237",
+          "date": "2019-03-03T22:46:34+04:00",
+          "sha256": "0pr68xcd2by5ld8rmrj5by677h4a4amjl358hp572d5jyk2bd5zz",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.3",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "cff3e2aad5cd4f7a11e62876f123c86743397d6f",
+          "date": "2019-03-02T10:17:41+04:00",
+          "sha256": "0pw7w2vy7hh62d6arpbib4vfx2zrim1gb8frdrwwc8rxppcb2l9p",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.0.2",
+        "value": {
+          "url": "https://github.com/moigagoo/norm",
+          "rev": "68b4d21a9f517a96a6345cb3a3863b783a046d4e",
+          "date": "2019-03-01T20:21:03+04:00",
+          "sha256": "16iwsnyn7cy48nvsamfzj7fbxzvk7w2q6vx1n33sl6iw32v2p31l",
           "fetchSubmodules": false
         }
       },

--- a/packages/npeg.json
+++ b/packages/npeg.json
@@ -4,76 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "bb25a195133f9f7af06386d0809793923cc5e8ab",
-          "date": "2019-03-31T22:21:17+02:00",
-          "sha256": "04fdrxs02wy862g575mq458dhnggv0qil1vdyyij30pbf7vn4m41",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "f446b6056eef6d8dc9d8b47a79aca93d17dc8230",
-          "date": "2019-03-30T19:39:34+01:00",
-          "sha256": "181wbdaj7lw9ic8ky40p9w1biyrp1dp45v8y9ibz4yqzzdwywh35",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "06c38bd8563d822455bc237c2a98c153d938ed1b",
-          "date": "2019-03-29T11:55:55+01:00",
-          "sha256": "1q9wn2mqdiz5h2imh7myyifzbn6gzb7az8sa5skg7izy5cv3gcfd",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "458c7b5910fcb157af3fc51bc3b3e663fdb3ed4a",
-          "date": "2019-03-27T21:46:11+01:00",
-          "sha256": "16xk7j0iqj44dlajyyag2l0j1nnj87fvc6sbrgvn27l8irnj63g0",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "39afdb5733d3245386d29d08c5ff61c89268f499",
-          "date": "2019-03-27T15:47:25+01:00",
-          "sha256": "0kgw8qrygmnmxgw8mgcf2p35pjv20yvi2nwfa2kbvwfk5c3a5ws4",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "1ea9868a3fee3aa487ab7ec9129208a4dd483d0d",
-          "date": "2019-03-24T15:53:51+01:00",
-          "sha256": "0c1whp1mj730gk1fc7225fg2zm0lkbd840idhpnivz9ayyhs6b5v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "45ea601e1c7f64fb857bc99df984b86673621d2c",
-          "date": "2019-03-21T23:42:56+01:00",
-          "sha256": "0fbmavf3l0rpkkw8zw814q7y4haz1s7cc8k5z26jm3lkn12sh72j",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.24.0",
         "value": {
           "url": "https://github.com/zevv/npeg",
@@ -206,16 +136,6 @@
         }
       },
       {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/zevv/npeg",
-          "rev": "d93d49c81fc8722d7929ac463b435c0f2e10c53b",
-          "date": "2019-03-20T17:23:42+01:00",
-          "sha256": "0c0b510mv7fbm5dwi9gnykd5l4l9r5rbjf144jsr65z5a3hm5f52",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.19.0",
         "value": {
           "url": "https://github.com/zevv/npeg",
@@ -332,6 +252,86 @@
           "rev": "4c959a72db5283b55eeef491076eefb5e02316f1",
           "date": "2019-04-24T20:09:38+02:00",
           "sha256": "1lvavrzbf3fyjyglspaykwdhcz1bsgnd8bssw5h8sn6lxgkvn9h3",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "bb25a195133f9f7af06386d0809793923cc5e8ab",
+          "date": "2019-03-31T22:21:17+02:00",
+          "sha256": "04fdrxs02wy862g575mq458dhnggv0qil1vdyyij30pbf7vn4m41",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "f446b6056eef6d8dc9d8b47a79aca93d17dc8230",
+          "date": "2019-03-30T19:39:34+01:00",
+          "sha256": "181wbdaj7lw9ic8ky40p9w1biyrp1dp45v8y9ibz4yqzzdwywh35",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "06c38bd8563d822455bc237c2a98c153d938ed1b",
+          "date": "2019-03-29T11:55:55+01:00",
+          "sha256": "1q9wn2mqdiz5h2imh7myyifzbn6gzb7az8sa5skg7izy5cv3gcfd",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "458c7b5910fcb157af3fc51bc3b3e663fdb3ed4a",
+          "date": "2019-03-27T21:46:11+01:00",
+          "sha256": "16xk7j0iqj44dlajyyag2l0j1nnj87fvc6sbrgvn27l8irnj63g0",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "39afdb5733d3245386d29d08c5ff61c89268f499",
+          "date": "2019-03-27T15:47:25+01:00",
+          "sha256": "0kgw8qrygmnmxgw8mgcf2p35pjv20yvi2nwfa2kbvwfk5c3a5ws4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "1ea9868a3fee3aa487ab7ec9129208a4dd483d0d",
+          "date": "2019-03-24T15:53:51+01:00",
+          "sha256": "0c1whp1mj730gk1fc7225fg2zm0lkbd840idhpnivz9ayyhs6b5v",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "45ea601e1c7f64fb857bc99df984b86673621d2c",
+          "date": "2019-03-21T23:42:56+01:00",
+          "sha256": "0fbmavf3l0rpkkw8zw814q7y4haz1s7cc8k5z26jm3lkn12sh72j",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/zevv/npeg",
+          "rev": "d93d49c81fc8722d7929ac463b435c0f2e10c53b",
+          "date": "2019-03-20T17:23:42+01:00",
+          "sha256": "0c0b510mv7fbm5dwi9gnykd5l4l9r5rbjf144jsr65z5a3hm5f52",
           "fetchSubmodules": false
         }
       },

--- a/packages/oauth.json
+++ b/packages/oauth.json
@@ -4,6 +4,16 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.10",
+        "value": {
+          "url": "https://github.com/CORDEA/oauth",
+          "rev": "2609e710ab76e61a503560b73618fc24eb97e8f9",
+          "date": "2020-02-17T20:55:05+09:00",
+          "sha256": "1rwzasds3c5jqxan5h5xg3b3bbb4byic490a7gbwmgq4cc41fdrg",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9",
         "value": {
           "url": "https://github.com/CORDEA/oauth",
@@ -90,16 +100,6 @@
           "rev": "df6074c0e47c08c3bc24eb0bff3c47060155c419",
           "date": "2016-06-26T11:50:03+09:00",
           "sha256": "1zcm2avfcip49ss790ylb29pcd7x1nf8sba4yz9h0szbfd8kkh63",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10",
-        "value": {
-          "url": "https://github.com/CORDEA/oauth",
-          "rev": "2609e710ab76e61a503560b73618fc24eb97e8f9",
-          "date": "2020-02-17T20:55:05+09:00",
-          "sha256": "1rwzasds3c5jqxan5h5xg3b3bbb4byic490a7gbwmgq4cc41fdrg",
           "fetchSubmodules": false
         }
       }

--- a/packages/p4ztag_to_json.json
+++ b/packages/p4ztag_to_json.json
@@ -4,6 +4,79 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.11.1",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "832c554e99f4e0ea5831435a466a7139b6195dd7",
+          "date": "2020-07-11T16:44:04-04:00",
+          "path": "/nix/store/wrnkk5am6brp6668dxn791k74p0g8rk3-p4ztag_to_json",
+          "sha256": "1caw8jh9fwgiv5cibp6q84z467m1xn1q8v0d110g9ddsnf45g3w3",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "4f3750a4a2004880982d6a0c07499ab1100575d9",
+          "date": "2019-11-21T11:25:53-05:00",
+          "sha256": "1rblw7g89b569h109r6cpyk8rmwav60n5ynlpzw7j7b4akppjali",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.4",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "36f4798b93ac3c3c9ac98e7a33c4ded9560d9675",
+          "date": "2019-10-10T11:44:56-04:00",
+          "sha256": "1l5dm4kfv9hh7kbnnw6hfrpxwinwzggzjzc9vqi5nqccx2kngf5w",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.3",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "95db7630f26af072ec18c331127b25b92a7d7daf",
+          "date": "2019-09-03T10:55:17-04:00",
+          "sha256": "12lp8k7xwb9k7hp3shv5ypkj2w6blj003n6pd4a9ks77k2kq2ak0",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.2",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "fdbc57ad324450ed1fd2363b75f622d721e00d9f",
+          "date": "2019-08-28T13:59:50-04:00",
+          "sha256": "15nii3x14m2hl08q18w0aak160fgpwximrv3vkawfjmmigva1hqf",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "bce69b3eff7b5c486d9bc28b3aa9170cd80f1ebd",
+          "date": "2019-08-09T16:59:10-04:00",
+          "sha256": "1cprpy6ffdbcrclm0c6lw9p907b734s6m29hhvk8h3samc15cnvv",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
+          "rev": "df7d87ac59b849c088bd993269728178e018c329",
+          "date": "2019-08-09T14:17:52-04:00",
+          "sha256": "153xclwk6y09hpf5v9m99lk9lbhzvg7x9ys0r1pn0mw2ylbfldlw",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.3",
         "value": {
           "url": "https://github.com/kaushalmodi/p4ztag_to_json",
@@ -150,79 +223,6 @@
           "rev": "742509f605acfc870c59c32b08762715de4ca8ec",
           "date": "2019-05-28T23:19:15-04:00",
           "sha256": "0wrwbmy36kzpjkrvx8n05h3l8z4l61h9h8yl22vpk7xrjygsxj50",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.1",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "832c554e99f4e0ea5831435a466a7139b6195dd7",
-          "date": "2020-07-11T16:44:04-04:00",
-          "path": "/nix/store/wrnkk5am6brp6668dxn791k74p0g8rk3-p4ztag_to_json",
-          "sha256": "1caw8jh9fwgiv5cibp6q84z467m1xn1q8v0d110g9ddsnf45g3w3",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "4f3750a4a2004880982d6a0c07499ab1100575d9",
-          "date": "2019-11-21T11:25:53-05:00",
-          "sha256": "1rblw7g89b569h109r6cpyk8rmwav60n5ynlpzw7j7b4akppjali",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.4",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "36f4798b93ac3c3c9ac98e7a33c4ded9560d9675",
-          "date": "2019-10-10T11:44:56-04:00",
-          "sha256": "1l5dm4kfv9hh7kbnnw6hfrpxwinwzggzjzc9vqi5nqccx2kngf5w",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.3",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "95db7630f26af072ec18c331127b25b92a7d7daf",
-          "date": "2019-09-03T10:55:17-04:00",
-          "sha256": "12lp8k7xwb9k7hp3shv5ypkj2w6blj003n6pd4a9ks77k2kq2ak0",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.2",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "fdbc57ad324450ed1fd2363b75f622d721e00d9f",
-          "date": "2019-08-28T13:59:50-04:00",
-          "sha256": "15nii3x14m2hl08q18w0aak160fgpwximrv3vkawfjmmigva1hqf",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "bce69b3eff7b5c486d9bc28b3aa9170cd80f1ebd",
-          "date": "2019-08-09T16:59:10-04:00",
-          "sha256": "1cprpy6ffdbcrclm0c6lw9p907b734s6m29hhvk8h3samc15cnvv",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/kaushalmodi/p4ztag_to_json",
-          "rev": "df7d87ac59b849c088bd993269728178e018c329",
-          "date": "2019-08-09T14:17:52-04:00",
-          "sha256": "153xclwk6y09hpf5v9m99lk9lbhzvg7x9ys0r1pn0mw2ylbfldlw",
           "fetchSubmodules": false
         }
       },

--- a/packages/paranim.json
+++ b/packages/paranim.json
@@ -4,6 +4,19 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/paranim/paranim",
+          "rev": "ff68bebd9d565674c93c4e041987640586ae9541",
+          "date": "2020-10-22T18:45:49-04:00",
+          "path": "/nix/store/g19qcl0ba3hcqi41v9dj1r85q8sn0gfc-paranim",
+          "sha256": "01vlg0n5k7zfmh1fzzrc9vni8z5m6gxhlvjskc46qsgd4v2a5s34",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.9.0",
         "value": {
           "url": "https://github.com/paranim/paranim",
@@ -99,19 +112,6 @@
           "date": "2020-02-25T13:29:26-05:00",
           "sha256": "1w9r1038agdzkbip7flql8pzk6bfzdjnh0f7cgbdviylvdcvc5fx",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/paranim/paranim",
-          "rev": "ff68bebd9d565674c93c4e041987640586ae9541",
-          "date": "2020-10-22T18:45:49-04:00",
-          "path": "/nix/store/g19qcl0ba3hcqi41v9dj1r85q8sn0gfc-paranim",
-          "sha256": "01vlg0n5k7zfmh1fzzrc9vni8z5m6gxhlvjskc46qsgd4v2a5s34",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/pararules.json
+++ b/packages/pararules.json
@@ -4,6 +4,45 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/paranim/pararules",
+          "rev": "60736075694cd9ac164dbb79573b5a9349a93c68",
+          "date": "2020-12-03T12:32:16-05:00",
+          "path": "/nix/store/81myflx5mxd80w5mmcdprgcrqm975fdw-pararules",
+          "sha256": "01i9pzv25l4yir5nl67n8144l8qlsk054265cfjzx0l6fds1n7aw",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/paranim/pararules",
+          "rev": "6da106508209b18a061ecc5ccdbb0495bd23f900",
+          "date": "2020-12-01T18:31:09-05:00",
+          "path": "/nix/store/06zqxnhv5782ph1wjg595pcmdjagnm98-pararules",
+          "sha256": "0vsm4681ddbxxk03nf7qpl13pb30i73588l2xqz66z15bj6xv9nv",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/paranim/pararules",
+          "rev": "90202d68c4fa287cb361e8a014c9d61eb5786778",
+          "date": "2020-11-25T11:25:00-05:00",
+          "path": "/nix/store/j20p88wc3pfdz39n2yydxbd159bdpqh1-pararules",
+          "sha256": "15598dr4and88y8s4z387s7p7mb5py3pj6bwp74pah1nmi9jhx2z",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.9.0",
         "value": {
           "url": "https://github.com/paranim/pararules",
@@ -102,45 +141,6 @@
           "date": "2020-02-25T13:26:53-05:00",
           "sha256": "0xq2iarir0y6kpy1idilm8l743z1v8vvbm2n0fd10fbpd5hylb37",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/paranim/pararules",
-          "rev": "60736075694cd9ac164dbb79573b5a9349a93c68",
-          "date": "2020-12-03T12:32:16-05:00",
-          "path": "/nix/store/81myflx5mxd80w5mmcdprgcrqm975fdw-pararules",
-          "sha256": "01i9pzv25l4yir5nl67n8144l8qlsk054265cfjzx0l6fds1n7aw",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/paranim/pararules",
-          "rev": "6da106508209b18a061ecc5ccdbb0495bd23f900",
-          "date": "2020-12-01T18:31:09-05:00",
-          "path": "/nix/store/06zqxnhv5782ph1wjg595pcmdjagnm98-pararules",
-          "sha256": "0vsm4681ddbxxk03nf7qpl13pb30i73588l2xqz66z15bj6xv9nv",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/paranim/pararules",
-          "rev": "90202d68c4fa287cb361e8a014c9d61eb5786778",
-          "date": "2020-11-25T11:25:00-05:00",
-          "path": "/nix/store/j20p88wc3pfdz39n2yydxbd159bdpqh1-pararules",
-          "sha256": "15598dr4and88y8s4z387s7p7mb5py3pj6bwp74pah1nmi9jhx2z",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/paravim.json
+++ b/packages/paravim.json
@@ -4,91 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "a542de1bca88973e1ae06153763bb0dfc3de447b",
-          "date": "2020-04-13T22:04:58-04:00",
-          "path": "/nix/store/kc4738d8lzp7qd7ijg3kzmjczmdq1dmj-paravim",
-          "sha256": "086mydljlwz0441gfkicvgbyfl8nxfhvjp35scp6mp9x1kkmrn5m",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "7d82e1fcf3eec3cbcdbd059bce328c84c85804db",
-          "date": "2020-03-24T15:17:37-04:00",
-          "sha256": "1dgal2ir0syk6kf05lh6f6q5zp8li4i6i7xklfbdlfdfz1hs8li6",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "d5158bb25b8c41f224ec33718f0c898e7a3b9e2b",
-          "date": "2020-03-22T20:37:27-04:00",
-          "sha256": "1kgfg2pcmysi6r8hrymbw2m30nkl8b9nhpg2mkc3f79k0p7jk76w",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "ebab0263f2666d23002b1f0167122d571d0ffe69",
-          "date": "2020-03-19T14:17:34-04:00",
-          "sha256": "15vkr48yzfnza1dbc1qfg8vn5vjys6civlg6jpai21sbpi5d0913",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "fbb5fcdf2d8bd74b1f157a8007bca87d34e4caf3",
-          "date": "2020-03-19T07:44:06-04:00",
-          "sha256": "11i6fdhh5mblr0mwjg7fnq7ipvmh57a7a72dzfgfci6wf91hy55b",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "dc232e4a2e5fe4eda0f569243d9d33b7923b6479",
-          "date": "2020-03-19T06:16:13-04:00",
-          "sha256": "0i1dlyr7vzkz799ahikll1b8zj4pzpiipr3yq8jf94vdswjwxnyf",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "8a7872ce34831b9f26e2289148b9a19eb4a434a2",
-          "date": "2020-03-18T20:04:31-04:00",
-          "sha256": "0dcqkywy0cw49rhfw0c5fa95anxpvjcwgg5zv7pbcckc8r62kslk",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/paranim/paravim",
-          "rev": "bfcf8cfb11f8beda7fe1535f47b2490116570ced",
-          "date": "2020-03-12T22:15:58-04:00",
-          "sha256": "13yhrfypm8nrjzc3ibs70bf23d7jvbkvcyzi03k3z3qnbcpw78v6",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.18.2",
         "value": {
           "url": "https://github.com/paranim/paravim",
@@ -255,6 +170,91 @@
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "a542de1bca88973e1ae06153763bb0dfc3de447b",
+          "date": "2020-04-13T22:04:58-04:00",
+          "path": "/nix/store/kc4738d8lzp7qd7ijg3kzmjczmdq1dmj-paravim",
+          "sha256": "086mydljlwz0441gfkicvgbyfl8nxfhvjp35scp6mp9x1kkmrn5m",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "7d82e1fcf3eec3cbcdbd059bce328c84c85804db",
+          "date": "2020-03-24T15:17:37-04:00",
+          "sha256": "1dgal2ir0syk6kf05lh6f6q5zp8li4i6i7xklfbdlfdfz1hs8li6",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "d5158bb25b8c41f224ec33718f0c898e7a3b9e2b",
+          "date": "2020-03-22T20:37:27-04:00",
+          "sha256": "1kgfg2pcmysi6r8hrymbw2m30nkl8b9nhpg2mkc3f79k0p7jk76w",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "ebab0263f2666d23002b1f0167122d571d0ffe69",
+          "date": "2020-03-19T14:17:34-04:00",
+          "sha256": "15vkr48yzfnza1dbc1qfg8vn5vjys6civlg6jpai21sbpi5d0913",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "fbb5fcdf2d8bd74b1f157a8007bca87d34e4caf3",
+          "date": "2020-03-19T07:44:06-04:00",
+          "sha256": "11i6fdhh5mblr0mwjg7fnq7ipvmh57a7a72dzfgfci6wf91hy55b",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "dc232e4a2e5fe4eda0f569243d9d33b7923b6479",
+          "date": "2020-03-19T06:16:13-04:00",
+          "sha256": "0i1dlyr7vzkz799ahikll1b8zj4pzpiipr3yq8jf94vdswjwxnyf",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "8a7872ce34831b9f26e2289148b9a19eb4a434a2",
+          "date": "2020-03-18T20:04:31-04:00",
+          "sha256": "0dcqkywy0cw49rhfw0c5fa95anxpvjcwgg5zv7pbcckc8r62kslk",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/paranim/paravim",
+          "rev": "bfcf8cfb11f8beda7fe1535f47b2490116570ced",
+          "date": "2020-03-12T22:15:58-04:00",
+          "sha256": "13yhrfypm8nrjzc3ibs70bf23d7jvbkvcyzi03k3z3qnbcpw78v6",
+          "fetchSubmodules": false
         }
       }
     ]

--- a/packages/patty.json
+++ b/packages/patty.json
@@ -77,6 +77,16 @@
         }
       },
       {
+        "name": "0.1.10",
+        "value": {
+          "url": "https://github.com/andreaferretti/patty",
+          "rev": "782265a20145bafdc2f41ce08dbcd6aa0a14def4",
+          "date": "2016-12-21T10:52:06+01:00",
+          "sha256": "0vw77lyq6zlgnnr4syfghi9ilyyi1g01b4xa9yd2vac3gx0lz2xp",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.1.9",
         "value": {
           "url": "https://github.com/andreaferretti/patty",
@@ -153,16 +163,6 @@
           "rev": "9d1882b4dc5a3076e688a829ba0cdfd054da33f7",
           "date": "2015-07-12T16:23:03+02:00",
           "sha256": "0m54j2bg2z15ssgvcrkgffz39fgj63q4hkpgi1av27ha77kpdg0n",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.10",
-        "value": {
-          "url": "https://github.com/andreaferretti/patty",
-          "rev": "782265a20145bafdc2f41ce08dbcd6aa0a14def4",
-          "date": "2016-12-21T10:52:06+01:00",
-          "sha256": "0vw77lyq6zlgnnr4syfghi9ilyyi1g01b4xa9yd2vac3gx0lz2xp",
           "fetchSubmodules": false
         }
       },

--- a/packages/picohttpparser.json
+++ b/packages/picohttpparser.json
@@ -4,22 +4,22 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/philip-wernersbach/nim-picohttpparser",
-          "rev": "e7bc46f8c4ce186adb907af0652436d145a8ed38",
-          "date": "2016-08-20T19:33:24-04:00",
-          "sha256": "0hmf95nkqqlwfzz5aj7fsqinhbhgh1267sssb5dclrsi254fisyw",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.10.0",
         "value": {
           "url": "https://github.com/philip-wernersbach/nim-picohttpparser",
           "rev": "5248bd34815542efa8e86fea45a7e1d051eb693d",
           "date": "2016-11-28T00:20:26-05:00",
           "sha256": "1vynasfhngrvi56bv95w7iqkbm2n9qp88ibdzq2hg09v9sqryncq",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/philip-wernersbach/nim-picohttpparser",
+          "rev": "e7bc46f8c4ce186adb907af0652436d145a8ed38",
+          "date": "2016-08-20T19:33:24-04:00",
+          "sha256": "0hmf95nkqqlwfzz5aj7fsqinhbhgh1267sssb5dclrsi254fisyw",
           "fetchSubmodules": false
         }
       }

--- a/packages/pvim.json
+++ b/packages/pvim.json
@@ -4,91 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.9.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "53a569358ac0570a059838c5cd4e7fdf8e06ee6a",
-          "date": "2020-04-13T22:08:22-04:00",
-          "path": "/nix/store/x4clqk1cnm4x5kfvql0d1kf1didyw5fy-pvim",
-          "sha256": "0wa80ivfk0q97cw39r27vl00jmcq58fix5j3fkxr602nrfqzzkhk",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "b42869603e9af4d62e79da92d556166ca9b94e73",
-          "date": "2020-03-24T15:18:20-04:00",
-          "sha256": "1xbhs47jyf17awsvk7z4vr3r0lx8f3b4zd00xfy5k9jf3zmczjwr",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "8624de68ead8315cbd61bb229fa8a033ea2aaef9",
-          "date": "2020-03-22T19:59:48-04:00",
-          "sha256": "0v7md03k2gnym8l04dlzgnsc1lm4gk81cx0fsql4drszflp9ah3h",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "820ab14ec11becec463ce14648433392ac36da68",
-          "date": "2020-03-19T14:18:26-04:00",
-          "sha256": "0wwl96lhyrawavrfljrxhgqpn4jsd57sscx5h3x2zbi8i6v4mdi4",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "ba708f2643686cda9ea4a2787f18cdaa381de904",
-          "date": "2020-03-19T07:44:40-04:00",
-          "sha256": "0qrsk1q42nvwsfskh23f7yr4zdyqhbydfnm60548xvza3naaplh9",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "0d92c9bea83a7ca4ee5982e097771c8872d1af22",
-          "date": "2020-03-19T06:17:39-04:00",
-          "sha256": "1d0gvpdhxva405kxq6ckp312icsa5mii922c7ryfjxdnsz86kh2b",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "769d40a553c88e207347225876ee65cc6504ba2f",
-          "date": "2020-03-18T19:54:26-04:00",
-          "sha256": "0w8df94ms28d7w30qj0l666d7y7ls0i32s6r3fllkx80pyylzjil",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/paranim/pvim",
-          "rev": "46fd2c813b5eabaf6c24ccbc9126c28e6c57d21e",
-          "date": "2020-03-12T22:17:18-04:00",
-          "sha256": "0q5y9y6w3w7g8ql6g3c090m64sjaxylgn2i0a1sif0q8fxh9gnb4",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.18.2",
         "value": {
           "url": "https://github.com/paranim/pvim",
@@ -255,6 +170,91 @@
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.9.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "53a569358ac0570a059838c5cd4e7fdf8e06ee6a",
+          "date": "2020-04-13T22:08:22-04:00",
+          "path": "/nix/store/x4clqk1cnm4x5kfvql0d1kf1didyw5fy-pvim",
+          "sha256": "0wa80ivfk0q97cw39r27vl00jmcq58fix5j3fkxr602nrfqzzkhk",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "b42869603e9af4d62e79da92d556166ca9b94e73",
+          "date": "2020-03-24T15:18:20-04:00",
+          "sha256": "1xbhs47jyf17awsvk7z4vr3r0lx8f3b4zd00xfy5k9jf3zmczjwr",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "8624de68ead8315cbd61bb229fa8a033ea2aaef9",
+          "date": "2020-03-22T19:59:48-04:00",
+          "sha256": "0v7md03k2gnym8l04dlzgnsc1lm4gk81cx0fsql4drszflp9ah3h",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "820ab14ec11becec463ce14648433392ac36da68",
+          "date": "2020-03-19T14:18:26-04:00",
+          "sha256": "0wwl96lhyrawavrfljrxhgqpn4jsd57sscx5h3x2zbi8i6v4mdi4",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "ba708f2643686cda9ea4a2787f18cdaa381de904",
+          "date": "2020-03-19T07:44:40-04:00",
+          "sha256": "0qrsk1q42nvwsfskh23f7yr4zdyqhbydfnm60548xvza3naaplh9",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "0d92c9bea83a7ca4ee5982e097771c8872d1af22",
+          "date": "2020-03-19T06:17:39-04:00",
+          "sha256": "1d0gvpdhxva405kxq6ckp312icsa5mii922c7ryfjxdnsz86kh2b",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "769d40a553c88e207347225876ee65cc6504ba2f",
+          "date": "2020-03-18T19:54:26-04:00",
+          "sha256": "0w8df94ms28d7w30qj0l666d7y7ls0i32s6r3fllkx80pyylzjil",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/paranim/pvim",
+          "rev": "46fd2c813b5eabaf6c24ccbc9126c28e6c57d21e",
+          "date": "2020-03-12T22:17:18-04:00",
+          "sha256": "0q5y9y6w3w7g8ql6g3c090m64sjaxylgn2i0a1sif0q8fxh9gnb4",
+          "fetchSubmodules": false
         }
       },
       {

--- a/packages/regex.json
+++ b/packages/regex.json
@@ -4,166 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.8.1",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "1a662170a0622720ddb8f3dec3407192c5972b4f",
-          "date": "2018-10-09T01:40:29-03:00",
-          "sha256": "1lhnjpmlrc2vgk19icbpq9s0hid9739f0n3cycggvlyi0fdz0ada",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.8.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "c0101cfac46ffc343109e75263f42b2022b06462",
-          "date": "2018-10-08T00:49:48-03:00",
-          "sha256": "1lzmla1g44z9w0r1wfly2b3kxa0lbkbnmic9swc9r40pcrcfyn5b",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.4",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "bd4d3389603e83277df8c013ec9de740eda77b5f",
-          "date": "2018-08-25T17:31:09-03:00",
-          "sha256": "0ri3382f9ivdzbbbi51lamrlidrr14qfghjia48w7blfpbmbd5m6",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.3",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "f57c62026091ab27dab6e7419e9ff5191c3317a2",
-          "date": "2018-08-16T22:04:10-03:00",
-          "sha256": "10nb8hnpwa97hh1xzjahspj5s2glxl7wabwp829s2z5vhir6m3xy",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.2",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "e69a8cfb0db4638f9989593a41450ad5f8258a84",
-          "date": "2018-08-16T20:39:59-03:00",
-          "sha256": "11h46yqfmssya4jh9pm5bb59m7yjcndapsadqvhqr3mgnr2zpgl5",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.1",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "631b222df174b0e689e702d8a97a8745747e4f90",
-          "date": "2018-06-09T09:43:53-03:00",
-          "sha256": "1i0hsij3xmakxyy4y514x6af822swwwgzc5382z3g0d4qgil62v6",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.7.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "5765d13daf58ca6a3d6ee5274b12961e4191dd9d",
-          "date": "2018-06-07T07:15:54-03:00",
-          "sha256": "0zihi882qrj26fk8x2xzlj6ybk3fbbkb7gzr402zg1a4jisljccq",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.3",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "8aab9cca2679f228e61c1982e822c55d78bd3b4a",
-          "date": "2018-05-02T22:33:59-03:00",
-          "sha256": "0qy1qzlw22pi8hpn9yn81b5crp8r85lgs428sgvnfi8d2qfyjla8",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.2",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "73f6e1b6d0d543db70c79a59bda36163d72b29e8",
-          "date": "2018-04-20T21:54:34-03:00",
-          "sha256": "017w2bk6mdv9immzgx2wsvdw639isw2h00cb5q99lb38xmx22a34",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.1",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "96c5cabeabf416ae570851db9d7bf7c0478f307e",
-          "date": "2018-03-14T21:46:26-03:00",
-          "sha256": "0zb6jbmihrxcw0zhdbjdk98bd3x9s8lwm3wdjrn3w85c6g4pwlx8",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.6.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "17cd100ff6271815b6b956b499618b124fca9467",
-          "date": "2018-03-13T23:06:11-03:00",
-          "sha256": "1qs5b1xbfnsi8p26psvy4fb9cfr03bbpyl2a0d951l5baiv0jdsx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.5.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "e5e8ef02ff07328e9242a333de88e8ac2cd29074",
-          "date": "2018-03-02T14:07:23-03:00",
-          "sha256": "0r9zwpzx8w24z7vivmx99dn7g5wz6qxpa37m9f0v3rdphmyhy8xy",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.1",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "89c5b411167c82e7af0aead475ff4efe299b2349",
-          "date": "2018-02-11T11:24:19-03:00",
-          "sha256": "1am7ay8w5rh3gky026bhhh7lrm2rkvzk46pnyl00n5jgg891i6rb",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.4.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "d566b3e67a24b02d10c5994d0df025aa46e1f931",
-          "date": "2018-02-10T07:50:12-03:00",
-          "sha256": "0yi761xzvdzqnvpc4yn4zjr701clp1hiadfi755hg1769n3pb9f5",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.3.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "794784bd0b6fa93d17b4931a3f63d37245fbec27",
-          "date": "2018-01-30T04:12:49-03:00",
-          "sha256": "16cky4dhni0z2s59m0gsk7x909gcn1437w6fwdbh9h49yvxxxjsh",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.0",
-        "value": {
-          "url": "https://github.com/nitely/nim-regex",
-          "rev": "f219f051cdac598c3deeb118f9bdc2a190099f66",
-          "date": "2018-01-26T19:41:08-03:00",
-          "sha256": "0chqj6pd87901n3kxjs8y427div0j5vz2cwpasr89gj5a1xs17vb",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.18.0",
         "value": {
           "url": "https://github.com/nitely/nim-regex",
@@ -357,6 +197,166 @@
           "rev": "31f3e283e5e992fe0f05c87fb4a885665b28525e",
           "date": "2018-10-27T22:33:28-03:00",
           "sha256": "1jlbypbzn0q36wh8l434na9mrhvk3q7palqyx1p66b3x2pbjf1kl",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.1",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "1a662170a0622720ddb8f3dec3407192c5972b4f",
+          "date": "2018-10-09T01:40:29-03:00",
+          "sha256": "1lhnjpmlrc2vgk19icbpq9s0hid9739f0n3cycggvlyi0fdz0ada",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.8.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "c0101cfac46ffc343109e75263f42b2022b06462",
+          "date": "2018-10-08T00:49:48-03:00",
+          "sha256": "1lzmla1g44z9w0r1wfly2b3kxa0lbkbnmic9swc9r40pcrcfyn5b",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.4",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "bd4d3389603e83277df8c013ec9de740eda77b5f",
+          "date": "2018-08-25T17:31:09-03:00",
+          "sha256": "0ri3382f9ivdzbbbi51lamrlidrr14qfghjia48w7blfpbmbd5m6",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.3",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "f57c62026091ab27dab6e7419e9ff5191c3317a2",
+          "date": "2018-08-16T22:04:10-03:00",
+          "sha256": "10nb8hnpwa97hh1xzjahspj5s2glxl7wabwp829s2z5vhir6m3xy",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.2",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "e69a8cfb0db4638f9989593a41450ad5f8258a84",
+          "date": "2018-08-16T20:39:59-03:00",
+          "sha256": "11h46yqfmssya4jh9pm5bb59m7yjcndapsadqvhqr3mgnr2zpgl5",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.1",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "631b222df174b0e689e702d8a97a8745747e4f90",
+          "date": "2018-06-09T09:43:53-03:00",
+          "sha256": "1i0hsij3xmakxyy4y514x6af822swwwgzc5382z3g0d4qgil62v6",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.7.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "5765d13daf58ca6a3d6ee5274b12961e4191dd9d",
+          "date": "2018-06-07T07:15:54-03:00",
+          "sha256": "0zihi882qrj26fk8x2xzlj6ybk3fbbkb7gzr402zg1a4jisljccq",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.3",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "8aab9cca2679f228e61c1982e822c55d78bd3b4a",
+          "date": "2018-05-02T22:33:59-03:00",
+          "sha256": "0qy1qzlw22pi8hpn9yn81b5crp8r85lgs428sgvnfi8d2qfyjla8",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.2",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "73f6e1b6d0d543db70c79a59bda36163d72b29e8",
+          "date": "2018-04-20T21:54:34-03:00",
+          "sha256": "017w2bk6mdv9immzgx2wsvdw639isw2h00cb5q99lb38xmx22a34",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.1",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "96c5cabeabf416ae570851db9d7bf7c0478f307e",
+          "date": "2018-03-14T21:46:26-03:00",
+          "sha256": "0zb6jbmihrxcw0zhdbjdk98bd3x9s8lwm3wdjrn3w85c6g4pwlx8",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.6.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "17cd100ff6271815b6b956b499618b124fca9467",
+          "date": "2018-03-13T23:06:11-03:00",
+          "sha256": "1qs5b1xbfnsi8p26psvy4fb9cfr03bbpyl2a0d951l5baiv0jdsx",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.5.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "e5e8ef02ff07328e9242a333de88e8ac2cd29074",
+          "date": "2018-03-02T14:07:23-03:00",
+          "sha256": "0r9zwpzx8w24z7vivmx99dn7g5wz6qxpa37m9f0v3rdphmyhy8xy",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.1",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "89c5b411167c82e7af0aead475ff4efe299b2349",
+          "date": "2018-02-11T11:24:19-03:00",
+          "sha256": "1am7ay8w5rh3gky026bhhh7lrm2rkvzk46pnyl00n5jgg891i6rb",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.4.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "d566b3e67a24b02d10c5994d0df025aa46e1f931",
+          "date": "2018-02-10T07:50:12-03:00",
+          "sha256": "0yi761xzvdzqnvpc4yn4zjr701clp1hiadfi755hg1769n3pb9f5",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.3.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "794784bd0b6fa93d17b4931a3f63d37245fbec27",
+          "date": "2018-01-30T04:12:49-03:00",
+          "sha256": "16cky4dhni0z2s59m0gsk7x909gcn1437w6fwdbh9h49yvxxxjsh",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.2.0",
+        "value": {
+          "url": "https://github.com/nitely/nim-regex",
+          "rev": "f219f051cdac598c3deeb118f9bdc2a190099f66",
+          "date": "2018-01-26T19:41:08-03:00",
+          "sha256": "0chqj6pd87901n3kxjs8y427div0j5vz2cwpasr89gj5a1xs17vb",
           "fetchSubmodules": false
         }
       },

--- a/packages/rosencrantz.json
+++ b/packages/rosencrantz.json
@@ -234,6 +234,36 @@
         }
       },
       {
+        "name": "0.1.12",
+        "value": {
+          "url": "https://github.com/andreaferretti/rosencrantz",
+          "rev": "6fa745da32ae36705e0d3f3b72cf55e06948e1cc",
+          "date": "2016-06-16T00:38:47+02:00",
+          "sha256": "00471n91da422maqbxvgs2vymbfq47zgp7f426i97f0y7mhxj8df",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.11",
+        "value": {
+          "url": "https://github.com/andreaferretti/rosencrantz",
+          "rev": "fd9bb20828f29f7846fbe5b2d83e70407c5ca60c",
+          "date": "2016-06-09T19:52:52+02:00",
+          "sha256": "1fv12gzkhjpsx4kig329p9x0i3ggjg6kycxscrydi953liskvc1v",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.10",
+        "value": {
+          "url": "https://github.com/andreaferretti/rosencrantz",
+          "rev": "3620f9dc76b7c98a5037b5e130eab1b202c3c797",
+          "date": "2016-06-05T18:31:58+02:00",
+          "sha256": "1ak7zfbhf2cafpgggdn0vl40lq5ksl1kqg27f0nlgmw1wjxjsv18",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.1.9",
         "value": {
           "url": "https://github.com/andreaferretti/rosencrantz",
@@ -310,36 +340,6 @@
           "rev": "a47ef271ea7ef0a3a5fb0660b7373d05d5e86cb4",
           "date": "2016-04-24T11:21:00+02:00",
           "sha256": "10p5gacwnsng851azdla5mc7naynbf5fcxr1lnvs8qjys58paifd",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.12",
-        "value": {
-          "url": "https://github.com/andreaferretti/rosencrantz",
-          "rev": "6fa745da32ae36705e0d3f3b72cf55e06948e1cc",
-          "date": "2016-06-16T00:38:47+02:00",
-          "sha256": "00471n91da422maqbxvgs2vymbfq47zgp7f426i97f0y7mhxj8df",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.11",
-        "value": {
-          "url": "https://github.com/andreaferretti/rosencrantz",
-          "rev": "fd9bb20828f29f7846fbe5b2d83e70407c5ca60c",
-          "date": "2016-06-09T19:52:52+02:00",
-          "sha256": "1fv12gzkhjpsx4kig329p9x0i3ggjg6kycxscrydi953liskvc1v",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.10",
-        "value": {
-          "url": "https://github.com/andreaferretti/rosencrantz",
-          "rev": "3620f9dc76b7c98a5037b5e130eab1b202c3c797",
-          "date": "2016-06-05T18:31:58+02:00",
-          "sha256": "1ak7zfbhf2cafpgggdn0vl40lq5ksl1kqg27f0nlgmw1wjxjsv18",
           "fetchSubmodules": false
         }
       },

--- a/packages/sam.json
+++ b/packages/sam.json
@@ -4,6 +4,81 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.1.16",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "30afca8101b1d3a67f3c15119fde421f17d7087e",
+          "date": "2020-11-25T22:02:51+07:00",
+          "path": "/nix/store/5k67yw57lgb3ih2z2rj08jlqawzsn1s0-sam.nim",
+          "sha256": "1701sziv8ib7fc10h4cs5jjdz9b1c50fmvw4amqlnsbim0b4f08a",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.15",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "a4ee0653963a9e916ac48bfc60d46f8120bb5c67",
+          "date": "2020-11-03T21:37:35+07:00",
+          "path": "/nix/store/1jj49j3bjpl9pd8q0rkb94g0c3jghns6-sam.nim",
+          "sha256": "0dfd80agfvi6b0aik731flksszrazs3ldw6f3fxq41g0q8bag6zd",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.14",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "6cbfd47ec369957bc74d3a4412af297b360e8b9b",
+          "date": "2020-11-03T20:19:59+07:00",
+          "path": "/nix/store/96nmypq6lgx5v929aiaa8pb3k2px2nkm-sam.nim",
+          "sha256": "025790nlvagg5p20426wbq96dcysaj1q8wy83ivvp85c4f63216r",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.13",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "b64086605a1a21c02b4974561b83d3c85701c795",
+          "date": "2020-11-03T15:07:16+07:00",
+          "path": "/nix/store/y4bfqqh7bpxyc6nkk440id5vcf44piwk-sam.nim",
+          "sha256": "016gxh15gq1imxy3m2f7rw5wx3zvgjavwp6csw794xh97dkvf0xw",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.12",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "9ecb5910c7897671cca7a2bf3df4033ceb8a5a5a",
+          "date": "2020-11-02T21:37:16+07:00",
+          "path": "/nix/store/bjl86llw5g45m7j5zgmll4xb0idpsjwg-sam.nim",
+          "sha256": "0vczq51ii5fmf267j3hjgni8rphsls19w98s84k68y5n30kf5ys3",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.11",
+        "value": {
+          "url": "https://github.com/OpenSystemsLab/sam.nim",
+          "rev": "0d52a639c9fdbabccc9c38d9d8809aa9220bf92e",
+          "date": "2020-02-10T00:39:21+07:00",
+          "sha256": "04kwiraf8zmaym2d7yfh4691ks5rv3b0riigan2gg975r55ldm1q",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.1.9",
         "value": {
           "url": "https://github.com/OpenSystemsLab/sam.nim",
@@ -80,81 +155,6 @@
           "rev": "b444a96057c5b6558cf14e5f080779c762b652ee",
           "date": "2016-03-11T17:49:27+07:00",
           "sha256": "1q8yj5bry8nq2b1gsigl3s20mb17bllwnl8pj693zszdvmm4fw9r",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.16",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "30afca8101b1d3a67f3c15119fde421f17d7087e",
-          "date": "2020-11-25T22:02:51+07:00",
-          "path": "/nix/store/5k67yw57lgb3ih2z2rj08jlqawzsn1s0-sam.nim",
-          "sha256": "1701sziv8ib7fc10h4cs5jjdz9b1c50fmvw4amqlnsbim0b4f08a",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.15",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "a4ee0653963a9e916ac48bfc60d46f8120bb5c67",
-          "date": "2020-11-03T21:37:35+07:00",
-          "path": "/nix/store/1jj49j3bjpl9pd8q0rkb94g0c3jghns6-sam.nim",
-          "sha256": "0dfd80agfvi6b0aik731flksszrazs3ldw6f3fxq41g0q8bag6zd",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.14",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "6cbfd47ec369957bc74d3a4412af297b360e8b9b",
-          "date": "2020-11-03T20:19:59+07:00",
-          "path": "/nix/store/96nmypq6lgx5v929aiaa8pb3k2px2nkm-sam.nim",
-          "sha256": "025790nlvagg5p20426wbq96dcysaj1q8wy83ivvp85c4f63216r",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.13",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "b64086605a1a21c02b4974561b83d3c85701c795",
-          "date": "2020-11-03T15:07:16+07:00",
-          "path": "/nix/store/y4bfqqh7bpxyc6nkk440id5vcf44piwk-sam.nim",
-          "sha256": "016gxh15gq1imxy3m2f7rw5wx3zvgjavwp6csw794xh97dkvf0xw",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.12",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "9ecb5910c7897671cca7a2bf3df4033ceb8a5a5a",
-          "date": "2020-11-02T21:37:16+07:00",
-          "path": "/nix/store/bjl86llw5g45m7j5zgmll4xb0idpsjwg-sam.nim",
-          "sha256": "0vczq51ii5fmf267j3hjgni8rphsls19w98s84k68y5n30kf5ys3",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.11",
-        "value": {
-          "url": "https://github.com/OpenSystemsLab/sam.nim",
-          "rev": "0d52a639c9fdbabccc9c38d9d8809aa9220bf92e",
-          "date": "2020-02-10T00:39:21+07:00",
-          "sha256": "04kwiraf8zmaym2d7yfh4691ks5rv3b0riigan2gg975r55ldm1q",
           "fetchSubmodules": false
         }
       }

--- a/packages/scram.json
+++ b/packages/scram.json
@@ -4,6 +4,58 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.1.13",
+        "value": {
+          "url": "https://github.com/rgv151/scram",
+          "rev": "0c08694ef749a29fbadad261ca31b1c23e08237b",
+          "date": "2020-07-21T07:49:42+07:00",
+          "path": "/nix/store/qc3236m34749q7595qhybppfh7j3q41r-scram",
+          "sha256": "10hpkn1qnkvicp0p98dc9wjfy290xlv3gdqww1vpway45ywd5f37",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.12",
+        "value": {
+          "url": "https://github.com/rgv151/scram",
+          "rev": "9f3130a4402b7b322a8e9e9519436bcf8974861c",
+          "date": "2020-07-20T09:17:38+07:00",
+          "path": "/nix/store/wz3gw8g37hnws7zdinddfviyavl9mnam-scram",
+          "sha256": "1rynl10dka27xcr03462ig20bbjcm5jhvgiml4w8l96glsn8zpc5",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.11",
+        "value": {
+          "url": "https://github.com/rgv151/scram",
+          "rev": "93ac668389f41e7f578e386b718a425b624c6914",
+          "date": "2020-07-07T20:15:00+07:00",
+          "path": "/nix/store/9jzn7n1xp0wqbq5s9d9412dccc2jjwah-scram",
+          "sha256": "0s8a7134m6c4gq74g1way5v8jimr19384hnkdk1pqvg475s4dqra",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.10",
+        "value": {
+          "url": "https://github.com/rgv151/scram",
+          "rev": "426d85d84269d1d0944b6e46e8fbbd8258fb94dd",
+          "date": "2020-04-08T08:42:00+07:00",
+          "path": "/nix/store/9w6zvqb0k1i7m68y2mk9ql31m9gqpczq-scram",
+          "sha256": "0bw1qllarg3q1kb8j68znc4sr98mfqhynh012m315b6gg3fbmnmm",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.1.9",
         "value": {
           "url": "https://github.com/rgv151/scram",
@@ -81,58 +133,6 @@
           "date": "2017-07-03T13:37:25+07:00",
           "sha256": "1j9mjjbc3dk57j6rz6mhmq6ga5yfw24qi8v49i4zcmnccxxpx3ls",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.13",
-        "value": {
-          "url": "https://github.com/rgv151/scram",
-          "rev": "0c08694ef749a29fbadad261ca31b1c23e08237b",
-          "date": "2020-07-21T07:49:42+07:00",
-          "path": "/nix/store/qc3236m34749q7595qhybppfh7j3q41r-scram",
-          "sha256": "10hpkn1qnkvicp0p98dc9wjfy290xlv3gdqww1vpway45ywd5f37",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.12",
-        "value": {
-          "url": "https://github.com/rgv151/scram",
-          "rev": "9f3130a4402b7b322a8e9e9519436bcf8974861c",
-          "date": "2020-07-20T09:17:38+07:00",
-          "path": "/nix/store/wz3gw8g37hnws7zdinddfviyavl9mnam-scram",
-          "sha256": "1rynl10dka27xcr03462ig20bbjcm5jhvgiml4w8l96glsn8zpc5",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.11",
-        "value": {
-          "url": "https://github.com/rgv151/scram",
-          "rev": "93ac668389f41e7f578e386b718a425b624c6914",
-          "date": "2020-07-07T20:15:00+07:00",
-          "path": "/nix/store/9jzn7n1xp0wqbq5s9d9412dccc2jjwah-scram",
-          "sha256": "0s8a7134m6c4gq74g1way5v8jimr19384hnkdk1pqvg475s4dqra",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.10",
-        "value": {
-          "url": "https://github.com/rgv151/scram",
-          "rev": "426d85d84269d1d0944b6e46e8fbbd8258fb94dd",
-          "date": "2020-04-08T08:42:00+07:00",
-          "path": "/nix/store/9w6zvqb0k1i7m68y2mk9ql31m9gqpczq-scram",
-          "sha256": "0bw1qllarg3q1kb8j68znc4sr98mfqhynh012m315b6gg3fbmnmm",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/sdl2_nim.json
+++ b/packages/sdl2_nim.json
@@ -4,6 +4,26 @@
     "method": "git",
     "versions": [
       {
+        "name": "2.0.12.0",
+        "value": {
+          "url": "https://github.com/Vladar4/sdl2_nim",
+          "rev": "292df934222cc83d07ecb82fba873ea0afbf8fb9",
+          "date": "2020-03-12T22:16:31+02:00",
+          "sha256": "1h5drkb300liy13fwhzymhgrcyawkkg9dzc0hzzhy9npl4pcgc71",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "2.0.10.0",
+        "value": {
+          "url": "https://github.com/Vladar4/sdl2_nim",
+          "rev": "575ff5b842a76d9cd774c2ba2531b866af681157",
+          "date": "2019-08-26T01:09:21+03:00",
+          "sha256": "1kpb180blz55sqrg58nhc812f0sr0xsrni4jd2q6zhf44i30blnh",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "2.0.9.2",
         "value": {
           "url": "https://github.com/Vladar4/sdl2_nim",
@@ -90,26 +110,6 @@
           "rev": "07e36481bf2094061977080c38b4e48d801ae4a8",
           "date": "2017-08-01T10:00:44+03:00",
           "sha256": "0k9v8kqfcvaa08grdsjjzjjimnz37kzailhv36h65znlj3v2s9wb",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "2.0.12.0",
-        "value": {
-          "url": "https://github.com/Vladar4/sdl2_nim",
-          "rev": "292df934222cc83d07ecb82fba873ea0afbf8fb9",
-          "date": "2020-03-12T22:16:31+02:00",
-          "sha256": "1h5drkb300liy13fwhzymhgrcyawkkg9dzc0hzzhy9npl4pcgc71",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "2.0.10.0",
-        "value": {
-          "url": "https://github.com/Vladar4/sdl2_nim",
-          "rev": "575ff5b842a76d9cd774c2ba2531b866af681157",
-          "date": "2019-08-26T01:09:21+03:00",
-          "sha256": "1kpb180blz55sqrg58nhc812f0sr0xsrni4jd2q6zhf44i30blnh",
           "fetchSubmodules": false
         }
       },

--- a/packages/serializetools.json
+++ b/packages/serializetools.json
@@ -4,6 +4,76 @@
     "method": "git",
     "versions": [
       {
+        "name": "1.13.0",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "6ae579a87840cd569325da7789bc14fe64d6c238",
+          "date": "2018-12-02T14:43:18-05:00",
+          "sha256": "06i9kk14hrpwpc7h2j0fvsax160f1462lhfjb74xxp83zvyahs0c",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.12.2",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "e99ec8f421a02852e426942403549c2b41d7fe00",
+          "date": "2018-11-25T14:13:22-05:00",
+          "sha256": "1cfdy8h269iwm7r3q87mjjidw0dbrhv74psc4nw7sbig3m0ssy6r",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.12.1",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "c0b45e34b065db54abc705c0346ba4a1ab3d05ba",
+          "date": "2018-11-25T13:11:40-05:00",
+          "sha256": "1na7b4rxi7wq3sing8zpb5whzcxv6cn69b4g6z5bx45lhrx2qb3m",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.12.0",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "5b5d73a503f27dc57d68f1f103059b61535935c9",
+          "date": "2018-11-24T16:57:03-05:00",
+          "sha256": "0rj1ls87b8jkv1y21s2i5b09wxp7cl8944552sp3c0v39nzjlqr7",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.11.0",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "954acc8a092eaca492a82fcc161020c402f28ee6",
+          "date": "2018-11-16T16:52:06-05:00",
+          "sha256": "1rwcmi01p07mv4yvqxs6knhrglka7wya51j2plpd35vxk1n7bndf",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.11",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "6cb656db66995b01c373cd269b7251d8d50e8c74",
+          "date": "2018-09-20T12:10:34-04:00",
+          "sha256": "1rj8qbrx193q8a0qf764bw8j6q2b3xk8nszbvbwzh9kzqfgbzz1x",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "1.10.0",
+        "value": {
+          "url": "https://github.com/JeffersonLab/serializetools",
+          "rev": "751b23235d7fe165dd99c88205d7775ee0f69be3",
+          "date": "2018-09-19T17:18:38-04:00",
+          "sha256": "19jz999z4wggn6l56y61ravp4w5ckx7gvfc4vnjs9spcwm6vcqqb",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "1.9.0",
         "value": {
           "url": "https://github.com/JeffersonLab/serializetools",
@@ -80,76 +150,6 @@
           "rev": "49c06ff0d23654f9b1bf8481d0fa68d15232de76",
           "date": "2017-05-27T01:28:00-04:00",
           "sha256": "0f0888pfqg3rsi6ihyv3xqsmklh59j56xdn6jgc3rib0kh6hzbpw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.13.0",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "6ae579a87840cd569325da7789bc14fe64d6c238",
-          "date": "2018-12-02T14:43:18-05:00",
-          "sha256": "06i9kk14hrpwpc7h2j0fvsax160f1462lhfjb74xxp83zvyahs0c",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.12.2",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "e99ec8f421a02852e426942403549c2b41d7fe00",
-          "date": "2018-11-25T14:13:22-05:00",
-          "sha256": "1cfdy8h269iwm7r3q87mjjidw0dbrhv74psc4nw7sbig3m0ssy6r",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.12.1",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "c0b45e34b065db54abc705c0346ba4a1ab3d05ba",
-          "date": "2018-11-25T13:11:40-05:00",
-          "sha256": "1na7b4rxi7wq3sing8zpb5whzcxv6cn69b4g6z5bx45lhrx2qb3m",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.12.0",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "5b5d73a503f27dc57d68f1f103059b61535935c9",
-          "date": "2018-11-24T16:57:03-05:00",
-          "sha256": "0rj1ls87b8jkv1y21s2i5b09wxp7cl8944552sp3c0v39nzjlqr7",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.11.0",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "954acc8a092eaca492a82fcc161020c402f28ee6",
-          "date": "2018-11-16T16:52:06-05:00",
-          "sha256": "1rwcmi01p07mv4yvqxs6knhrglka7wya51j2plpd35vxk1n7bndf",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.11",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "6cb656db66995b01c373cd269b7251d8d50e8c74",
-          "date": "2018-09-20T12:10:34-04:00",
-          "sha256": "1rj8qbrx193q8a0qf764bw8j6q2b3xk8nszbvbwzh9kzqfgbzz1x",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.10.0",
-        "value": {
-          "url": "https://github.com/JeffersonLab/serializetools",
-          "rev": "751b23235d7fe165dd99c88205d7775ee0f69be3",
-          "date": "2018-09-19T17:18:38-04:00",
-          "sha256": "19jz999z4wggn6l56y61ravp4w5ckx7gvfc4vnjs9spcwm6vcqqb",
           "fetchSubmodules": false
         }
       },

--- a/packages/sigv4.json
+++ b/packages/sigv4.json
@@ -4,6 +4,19 @@
     "method": "git",
     "versions": [
       {
+        "name": "1.0.10",
+        "value": {
+          "url": "https://github.com/disruptek/sigv4",
+          "rev": "e4fdfe721decbc821394ec8a2fdd2393dc24b237",
+          "date": "2020-09-08T00:09:24-04:00",
+          "path": "/nix/store/bfwhx4bqszcbbzbfq2k6jsafsf3pacp5-sigv4",
+          "sha256": "0wdpryq2hmw1vqr3fmjgjhqcpzhrxvz55ahma334z9w5f98mffz9",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "1.0.9",
         "value": {
           "url": "https://github.com/disruptek/sigv4",
@@ -93,19 +106,6 @@
           "date": "2019-09-23T14:14:13-04:00",
           "sha256": "1i8ss1y2kf7fya8qjsfw18i5jzfhhk8lq5j37mlh4v44j1apz6fi",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.10",
-        "value": {
-          "url": "https://github.com/disruptek/sigv4",
-          "rev": "e4fdfe721decbc821394ec8a2fdd2393dc24b237",
-          "date": "2020-09-08T00:09:24-04:00",
-          "path": "/nix/store/bfwhx4bqszcbbzbfq2k6jsafsf3pacp5-sigv4",
-          "sha256": "0wdpryq2hmw1vqr3fmjgjhqcpzhrxvz55ahma334z9w5f98mffz9",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/simple_parseopt.json
+++ b/packages/simple_parseopt.json
@@ -16,6 +16,18 @@
         }
       },
       {
+        "name": "1.0.10",
+        "value": {
+          "url": "https://github.com/onelivesleft/simple_parseopt",
+          "rev": "1e3bb40f0cf367cae23214128b2e506b5e65827f",
+          "date": "2020-03-24T14:27:07+00:00",
+          "sha256": "1bzm4q9l9wlqibpkhqdn8yfjqj6na8lzf8r1pz1164b4xipg1j6q",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "1.0.9",
         "value": {
           "url": "https://github.com/onelivesleft/simple_parseopt",
@@ -35,18 +47,6 @@
           "date": "2019-12-03T14:47:14+00:00",
           "sha256": "04zpavz0jbviljld5zvknynw5ja0z81l4b1c0d9yh5qjijrsyfhc",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.10",
-        "value": {
-          "url": "https://github.com/onelivesleft/simple_parseopt",
-          "rev": "1e3bb40f0cf367cae23214128b2e506b5e65827f",
-          "date": "2020-03-24T14:27:07+00:00",
-          "sha256": "1bzm4q9l9wlqibpkhqdn8yfjqj6na8lzf8r1pz1164b4xipg1j6q",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       }
     ]

--- a/packages/ternary_tree.json
+++ b/packages/ternary_tree.json
@@ -4,91 +4,13 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.1.9",
+        "name": "0.1.28",
         "value": {
           "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "d15ee1993a0fa66106a38332465b6f178c1f9cab",
-          "date": "2020-10-05T12:39:06+08:00",
-          "path": "/nix/store/422kzp8w6mxjld39dxh34is5pgdfin2w-ternary-tree",
-          "sha256": "10y59r75p8ri06afzwk34kmsv690vyjbgjl87hm3n1cyilxgcasb",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.8",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "6d8fd28a2b64be2de533010765c57edbfd000662",
-          "date": "2020-10-03T00:11:24+08:00",
-          "path": "/nix/store/4ysrx9l326qhg65na3q4d1198mhs135f-ternary-tree",
-          "sha256": "0l59xd0iv7h1cp953y69ijkssgxkh50s8sxf6hn2nvs9rccraxsj",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.7",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "cf92fa287fcde03caf0631ec5f94021de70100e7",
-          "date": "2020-10-01T15:44:13+08:00",
-          "path": "/nix/store/ndr2nnbm7k7mf6nas6rqnn58qjl2s6lr-ternary-tree",
-          "sha256": "0pp8hhz6588wlvaa8lw7gm3pk4kb2955ndi4ivg2imzrhyjiqnjg",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.6",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "82bc6e10601bbb2478d07d19d52068a9062c5f9f",
-          "date": "2020-09-28T14:26:18+08:00",
-          "path": "/nix/store/86vfc8iv72zvwvif1gfzz4m1mlq3pl64-ternary-tree",
-          "sha256": "1vcb54yshkj5qvldhl7z50rcqiqhav5s9a1bim1ydg9k8z1f2wnp",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.5",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "4389703744bb9a7c0183e737b8349acea4ecf42e",
-          "date": "2020-09-28T14:19:01+08:00",
-          "path": "/nix/store/9k61ddg82iag2md2372iamlr32nc5amd-ternary-tree",
-          "sha256": "0vl5fa1i5iwvm1bqp6gpnismfwam8b75k3ij48zs5l3vkkgddmh2",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.4",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "9940a3d33c8bd69e07854ef193b47b358c822ec6",
-          "date": "2020-09-28T12:53:04+08:00",
-          "path": "/nix/store/gphrlh6g8vkgdsampvzls223fx8519ha-ternary-tree",
-          "sha256": "0w11l58nmxhhrvcyxlz82ybm8zy562hnh290ihmk32a6qyifr53l",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.3",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "e9770f8612339074597337d39fb3a6c57ee4e45e",
-          "date": "2020-09-28T00:30:09+08:00",
-          "path": "/nix/store/b0k8bbs2bmcizhy7962s6nqw0xkc8bjm-ternary-tree",
-          "sha256": "0h42dyr6yipsylf551zqim85x1x8j9h82mmday6n4hi6vprjdvlm",
+          "rev": "cc5f1f8e7b1892bf76923fd7cc15b71490b03a1c",
+          "date": "2020-12-13T14:54:27+08:00",
+          "path": "/nix/store/3rvdpk0d17vj89f5pk0nxw3raz1qbi6i-ternary-tree",
+          "sha256": "12a81qgcf1z8j601y246h7n72xrq5kw8ksj58ycjypy41s01rjcs",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
@@ -193,19 +115,6 @@
           "date": "2020-10-15T14:00:39+08:00",
           "path": "/nix/store/p6nr35iw5m0x55f3zr9fg0z73wxxsc5x-ternary-tree",
           "sha256": "0w689v2alk8v7v99ck0i8dhs8hrbw670lyrx52zd8g8w0xpz2lab",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.2",
-        "value": {
-          "url": "https://github.com/calcit-lang/ternary-tree",
-          "rev": "930d97fe76a69b548780d320eeec006af63e389f",
-          "date": "2020-09-28T00:08:13+08:00",
-          "path": "/nix/store/qbnz632m3n0p2bk365xr7ss6806apapr-ternary-tree",
-          "sha256": "0nbz9jhssyqb34r9j5x7rd8y0wwg08wxnc6kcw9f8qiv97ka5nhk",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false
@@ -336,6 +245,110 @@
           "date": "2020-10-04T12:10:58+08:00",
           "path": "/nix/store/r9q6frrzp2sx5w0b4i55ac42015nxksc-ternary-tree",
           "sha256": "0g8qmhc4c0ygz5pbx56fha1ln7lr4fzjyxgi5bgb2f5v7i63y2hf",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.9",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "d15ee1993a0fa66106a38332465b6f178c1f9cab",
+          "date": "2020-10-05T12:39:06+08:00",
+          "path": "/nix/store/422kzp8w6mxjld39dxh34is5pgdfin2w-ternary-tree",
+          "sha256": "10y59r75p8ri06afzwk34kmsv690vyjbgjl87hm3n1cyilxgcasb",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.8",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "6d8fd28a2b64be2de533010765c57edbfd000662",
+          "date": "2020-10-03T00:11:24+08:00",
+          "path": "/nix/store/4ysrx9l326qhg65na3q4d1198mhs135f-ternary-tree",
+          "sha256": "0l59xd0iv7h1cp953y69ijkssgxkh50s8sxf6hn2nvs9rccraxsj",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.7",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "cf92fa287fcde03caf0631ec5f94021de70100e7",
+          "date": "2020-10-01T15:44:13+08:00",
+          "path": "/nix/store/ndr2nnbm7k7mf6nas6rqnn58qjl2s6lr-ternary-tree",
+          "sha256": "0pp8hhz6588wlvaa8lw7gm3pk4kb2955ndi4ivg2imzrhyjiqnjg",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.6",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "82bc6e10601bbb2478d07d19d52068a9062c5f9f",
+          "date": "2020-09-28T14:26:18+08:00",
+          "path": "/nix/store/86vfc8iv72zvwvif1gfzz4m1mlq3pl64-ternary-tree",
+          "sha256": "1vcb54yshkj5qvldhl7z50rcqiqhav5s9a1bim1ydg9k8z1f2wnp",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.5",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "4389703744bb9a7c0183e737b8349acea4ecf42e",
+          "date": "2020-09-28T14:19:01+08:00",
+          "path": "/nix/store/9k61ddg82iag2md2372iamlr32nc5amd-ternary-tree",
+          "sha256": "0vl5fa1i5iwvm1bqp6gpnismfwam8b75k3ij48zs5l3vkkgddmh2",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.4",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "9940a3d33c8bd69e07854ef193b47b358c822ec6",
+          "date": "2020-09-28T12:53:04+08:00",
+          "path": "/nix/store/gphrlh6g8vkgdsampvzls223fx8519ha-ternary-tree",
+          "sha256": "0w11l58nmxhhrvcyxlz82ybm8zy562hnh290ihmk32a6qyifr53l",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.3",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "e9770f8612339074597337d39fb3a6c57ee4e45e",
+          "date": "2020-09-28T00:30:09+08:00",
+          "path": "/nix/store/b0k8bbs2bmcizhy7962s6nqw0xkc8bjm-ternary-tree",
+          "sha256": "0h42dyr6yipsylf551zqim85x1x8j9h82mmday6n4hi6vprjdvlm",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.2",
+        "value": {
+          "url": "https://github.com/calcit-lang/ternary-tree",
+          "rev": "930d97fe76a69b548780d320eeec006af63e389f",
+          "date": "2020-09-28T00:08:13+08:00",
+          "path": "/nix/store/qbnz632m3n0p2bk365xr7ss6806apapr-ternary-tree",
+          "sha256": "0nbz9jhssyqb34r9j5x7rd8y0wwg08wxnc6kcw9f8qiv97ka5nhk",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/packages/torch.json
+++ b/packages/torch.json
@@ -44,66 +44,6 @@
         }
       },
       {
-        "name": "0.1.9",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "233eeaf500121fe135d7e054f757e35ba33edabb",
-          "date": "2018-07-29T16:40:17+02:00",
-          "sha256": "1bqvss7d4cy0imgndghm5wninff3jz7xhsjyrl54yhks086i02ql",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.8",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "16da995017d6c4d6247dd342750eb7da82ccb88e",
-          "date": "2018-07-28T10:04:29+02:00",
-          "sha256": "0myp9yyzn25jcr81q22byr0k473l0bk118v2l87vfgf7ayiw4hh0",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.6",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "68a28a62d3b8b15cdc97e88eb718f8cafbf88264",
-          "date": "2018-07-28T01:51:08+02:00",
-          "sha256": "16dhpgbw3kvb7qi729rb4v8fgjix3dchgjspmymidkmfrbq6dzm8",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.5",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "1c3bc3bdf77564342e30859db5b53796f31579bb",
-          "date": "2018-07-27T19:36:18+02:00",
-          "sha256": "0dy31nw7l0a3lns43iagq72jiw5yvc4722pfx18a292qwiksnk4h",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.4",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "1be6422ba3f450dd789ea33ce42b51cd942cd39a",
-          "date": "2018-07-27T18:59:43+02:00",
-          "sha256": "0wbrfp7ldks3dc8cqw4597gagyjy925fnp5i51x5i6zx5yj1jifa",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.3",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "ec67bb483701364ba373c90d85c9b755151a5847",
-          "date": "2018-07-27T18:29:04+02:00",
-          "sha256": "0x15jp75wbkxzjsxbmllb9cywvrzr5c8r87n92dh563rmdj72k6k",
-          "fetchSubmodules": false
-        }
-      },
-      {
         "name": "0.1.24",
         "value": {
           "url": "https://github.com/fragcolor-xyz/nimtorch",
@@ -150,16 +90,6 @@
           "rev": "075a79c98f4a47395131eddd541f3f06523f36d2",
           "date": "2018-08-24T07:35:38+00:00",
           "sha256": "1snzclrzyamy7kv34a75c4wws5gplbbxaa7x54sgn9hxx6f016kq",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.2",
-        "value": {
-          "url": "https://github.com/fragcolor-xyz/nimtorch",
-          "rev": "10c0b95b953efa53dfce9b8733920966f941734b",
-          "date": "2018-07-27T18:11:12+02:00",
-          "sha256": "1wkakl0hziqmx9aaqgk8dyrx5jj560jy2vp8dgkwy08j3vkmssgm",
           "fetchSubmodules": false
         }
       },
@@ -250,6 +180,76 @@
           "rev": "e475fe148a2dbe051fed39770f43828b6c1de269",
           "date": "2018-07-29T18:11:37+02:00",
           "sha256": "1lgnnb0a3j17mdxz3h3vyvag7cax9wbz09ngfbd6m3lig0yfam10",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.9",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "233eeaf500121fe135d7e054f757e35ba33edabb",
+          "date": "2018-07-29T16:40:17+02:00",
+          "sha256": "1bqvss7d4cy0imgndghm5wninff3jz7xhsjyrl54yhks086i02ql",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.8",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "16da995017d6c4d6247dd342750eb7da82ccb88e",
+          "date": "2018-07-28T10:04:29+02:00",
+          "sha256": "0myp9yyzn25jcr81q22byr0k473l0bk118v2l87vfgf7ayiw4hh0",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.6",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "68a28a62d3b8b15cdc97e88eb718f8cafbf88264",
+          "date": "2018-07-28T01:51:08+02:00",
+          "sha256": "16dhpgbw3kvb7qi729rb4v8fgjix3dchgjspmymidkmfrbq6dzm8",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.5",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "1c3bc3bdf77564342e30859db5b53796f31579bb",
+          "date": "2018-07-27T19:36:18+02:00",
+          "sha256": "0dy31nw7l0a3lns43iagq72jiw5yvc4722pfx18a292qwiksnk4h",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.4",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "1be6422ba3f450dd789ea33ce42b51cd942cd39a",
+          "date": "2018-07-27T18:59:43+02:00",
+          "sha256": "0wbrfp7ldks3dc8cqw4597gagyjy925fnp5i51x5i6zx5yj1jifa",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.3",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "ec67bb483701364ba373c90d85c9b755151a5847",
+          "date": "2018-07-27T18:29:04+02:00",
+          "sha256": "0x15jp75wbkxzjsxbmllb9cywvrzr5c8r87n92dh563rmdj72k6k",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.1.2",
+        "value": {
+          "url": "https://github.com/fragcolor-xyz/nimtorch",
+          "rev": "10c0b95b953efa53dfce9b8733920966f941734b",
+          "date": "2018-07-27T18:11:12+02:00",
+          "sha256": "1wkakl0hziqmx9aaqgk8dyrx5jj560jy2vp8dgkwy08j3vkmssgm",
           "fetchSubmodules": false
         }
       },

--- a/packages/uuids.json
+++ b/packages/uuids.json
@@ -4,6 +4,16 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.1.10",
+        "value": {
+          "url": "https://github.com/pragmagic/uuids/",
+          "rev": "c5039c1cc6a8a93fc2f3c03a206372eb4412e63b",
+          "date": "2018-09-05T15:00:33+07:00",
+          "sha256": "1fj6v8i2gzyp2amv1gmqnbn7gnccy582rbag3yx98sv149nh1n97",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.1.9",
         "value": {
           "url": "https://github.com/pragmagic/uuids/",
@@ -80,16 +90,6 @@
           "rev": "c6783039ac1eda4fb5801c7363c39e60bd9276fd",
           "date": "2016-10-23T20:51:22+07:00",
           "sha256": "060zcs020ymp65d69mhk05c0s8ngf4bl7vfcad56n4h2ai12q5a4",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.10",
-        "value": {
-          "url": "https://github.com/pragmagic/uuids/",
-          "rev": "c5039c1cc6a8a93fc2f3c03a206372eb4412e63b",
-          "date": "2018-09-05T15:00:33+07:00",
-          "sha256": "1fj6v8i2gzyp2amv1gmqnbn7gnccy582rbag3yx98sv149nh1n97",
           "fetchSubmodules": false
         }
       },

--- a/packages/variant.json
+++ b/packages/variant.json
@@ -4,6 +4,16 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.2.10",
+        "value": {
+          "url": "https://github.com/yglukhov/variant.git",
+          "rev": "0afd40fff7c4ea8042ad9dab0c958fcc2ebb4fa7",
+          "date": "2019-06-03T21:14:22+08:00",
+          "sha256": "14zhp6bljv9nhrfyfaz1s3a80b20vpwyacafa45dkffs07lvr3k9",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.2.9",
         "value": {
           "url": "https://github.com/yglukhov/variant.git",
@@ -80,16 +90,6 @@
           "rev": "c984d663a850e9b4da97bf4c73c9ebbfbd0e4041",
           "date": "2017-06-17T14:24:26+03:00",
           "sha256": "0dbb66w0zmsl3ldwkasdafpqw1mj08yxjh7ihghmmsvcwz2nlcpx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.2.10",
-        "value": {
-          "url": "https://github.com/yglukhov/variant.git",
-          "rev": "0afd40fff7c4ea8042ad9dab0c958fcc2ebb4fa7",
-          "date": "2019-06-03T21:14:22+08:00",
-          "sha256": "14zhp6bljv9nhrfyfaz1s3a80b20vpwyacafa45dkffs07lvr3k9",
           "fetchSubmodules": false
         }
       },

--- a/packages/yaml.json
+++ b/packages/yaml.json
@@ -4,6 +4,109 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.14.0",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "aa64bac5ed68c519ecc0e101056aa934ef476438",
+          "date": "2020-06-26T23:25:12+02:00",
+          "path": "/nix/store/qsv065yxh3gb9skb7ckki9114las3sp9-NimYAML",
+          "sha256": "0w4l66g8813bq24knf2lsmskn43jzzkn4zq7ndrrc4irf0gay9nx",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.13.1",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "96254f1900a59664acaf38ebd599ccc9716af30c",
+          "date": "2020-03-22T11:57:00+01:00",
+          "sha256": "04qa8ihp97kkb6sbi0h40srzq4fri5rj5nz6aw1lcxz97a0yd9vx",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.13.0",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "9a81ae982fbfa876cdf99598fc973f518d8a0a94",
+          "date": "2020-03-08T20:05:13+01:00",
+          "sha256": "19ry4yih3xd51g08j2sckgs8wx5gy5gv6hxjwapn21j02j9k0fds",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.12.0",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "e6ac75d86af8f8eae9a010c8e639c3ac4263f8df",
+          "date": "2019-09-06T16:38:21+02:00",
+          "sha256": "0h7k32q5vbrbsn0ff7mbz3zhc5fv2hmwcnk3k1bxkidh3rr54ah1",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.11.0",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "b4936a14dd80a17236a32ff8e30fb55706ded7c9",
+          "date": "2018-10-12T16:07:41+02:00",
+          "sha256": "1p9h5qfjvc3is91jdwhdjqdi22d4i0jzdc6q01d9ypyj2lackx1c",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.4",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "2328289dba14c5167261b936c2b42eac19111d11",
+          "date": "2018-05-29T19:12:03+02:00",
+          "sha256": "0pk6imp4baafq9ncdmrxv9cl0c5dzb6n4cddp8gx9cdmm56byvaw",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.3",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "e7e532ccb8985f7d356e9c971d739654b0782bff",
+          "date": "2017-09-20T19:04:57+02:00",
+          "sha256": "0swxv38lr9bw37cljif2bp7qjf8h5yc9vhixa60lgbzf700silzq",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.2",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "af58ab68de481bae7eabbf59088656620e32b1bd",
+          "date": "2017-08-30T18:14:08+02:00",
+          "sha256": "1b5a7vfp02yic0rhc7pd13b8gcgihgrs90bgfv574dckx9cqvsfy",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.1",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "27d8eaeb35f9ec6f219b9ac3dd24c28b1a557c38",
+          "date": "2017-07-10T20:42:49+02:00",
+          "sha256": "1fzhhx50rv9pc3p5l84lw811blykgsmvwd1a48q7vwln0fj4q75s",
+          "fetchSubmodules": false
+        }
+      },
+      {
+        "name": "0.10.0",
+        "value": {
+          "url": "https://github.com/flyx/NimYAML",
+          "rev": "15f8995ae2bc76eed63ea118d19c08e61044af22",
+          "date": "2017-06-30T16:45:32+02:00",
+          "sha256": "0xb43m9czixfmj4z76lhfsa6sy99bai4ia54dnm3knnmykwklhqf",
+          "fetchSubmodules": false
+        }
+      },
+      {
         "name": "0.9.1",
         "value": {
           "url": "https://github.com/flyx/NimYAML",
@@ -130,109 +233,6 @@
           "rev": "59d2739b79173332cf2cc09f34f644762d50ab86",
           "date": "2016-02-25T22:44:41+01:00",
           "sha256": "0sa6r5l5zk1690ab2j206hnxxa20ppzp64s9dd47sngl0fjxiqax",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.14.0",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "aa64bac5ed68c519ecc0e101056aa934ef476438",
-          "date": "2020-06-26T23:25:12+02:00",
-          "path": "/nix/store/qsv065yxh3gb9skb7ckki9114las3sp9-NimYAML",
-          "sha256": "0w4l66g8813bq24knf2lsmskn43jzzkn4zq7ndrrc4irf0gay9nx",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.13.1",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "96254f1900a59664acaf38ebd599ccc9716af30c",
-          "date": "2020-03-22T11:57:00+01:00",
-          "sha256": "04qa8ihp97kkb6sbi0h40srzq4fri5rj5nz6aw1lcxz97a0yd9vx",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.13.0",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "9a81ae982fbfa876cdf99598fc973f518d8a0a94",
-          "date": "2020-03-08T20:05:13+01:00",
-          "sha256": "19ry4yih3xd51g08j2sckgs8wx5gy5gv6hxjwapn21j02j9k0fds",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.12.0",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "e6ac75d86af8f8eae9a010c8e639c3ac4263f8df",
-          "date": "2019-09-06T16:38:21+02:00",
-          "sha256": "0h7k32q5vbrbsn0ff7mbz3zhc5fv2hmwcnk3k1bxkidh3rr54ah1",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.11.0",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "b4936a14dd80a17236a32ff8e30fb55706ded7c9",
-          "date": "2018-10-12T16:07:41+02:00",
-          "sha256": "1p9h5qfjvc3is91jdwhdjqdi22d4i0jzdc6q01d9ypyj2lackx1c",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.4",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "2328289dba14c5167261b936c2b42eac19111d11",
-          "date": "2018-05-29T19:12:03+02:00",
-          "sha256": "0pk6imp4baafq9ncdmrxv9cl0c5dzb6n4cddp8gx9cdmm56byvaw",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.3",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "e7e532ccb8985f7d356e9c971d739654b0782bff",
-          "date": "2017-09-20T19:04:57+02:00",
-          "sha256": "0swxv38lr9bw37cljif2bp7qjf8h5yc9vhixa60lgbzf700silzq",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.2",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "af58ab68de481bae7eabbf59088656620e32b1bd",
-          "date": "2017-08-30T18:14:08+02:00",
-          "sha256": "1b5a7vfp02yic0rhc7pd13b8gcgihgrs90bgfv574dckx9cqvsfy",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.1",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "27d8eaeb35f9ec6f219b9ac3dd24c28b1a557c38",
-          "date": "2017-07-10T20:42:49+02:00",
-          "sha256": "1fzhhx50rv9pc3p5l84lw811blykgsmvwd1a48q7vwln0fj4q75s",
-          "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.10.0",
-        "value": {
-          "url": "https://github.com/flyx/NimYAML",
-          "rev": "15f8995ae2bc76eed63ea118d19c08e61044af22",
-          "date": "2017-06-30T16:45:32+02:00",
-          "sha256": "0xb43m9czixfmj4z76lhfsa6sy99bai4ia54dnm3knnmykwklhqf",
           "fetchSubmodules": false
         }
       },

--- a/packages/zfblast.json
+++ b/packages/zfblast.json
@@ -4,6 +4,84 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.1.19",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "f71008da3ea3690da9f5951e98645952673629f5",
+          "date": "2020-09-21T09:22:35+07:00",
+          "path": "/nix/store/5npzn1c19bwnzz8dyzad78hk24qv6s72-nim.zfblast",
+          "sha256": "1j1qj8nn14piypwaa3nwigj2yrvn0573fdcwb11rm7kpj3ks8bfr",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.17-old",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "ea7349c4d28e5b08e3f7afd1dd9910e41f0e8caf",
+          "date": "2020-07-25T13:11:30+07:00",
+          "path": "/nix/store/i152s9aihmzrg8yhf75dlh3c6gm7h1x4-nim.zfblast",
+          "sha256": "0h91j7hhv1fr7zqgrmmis99bs2r6lg2vcjs3gjmx7jk3pmcmz3wp",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.17",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "b6b81e39a7c325152a5a5e673fb2e1dbfacd7db6",
+          "date": "2020-07-25T07:35:53+07:00",
+          "path": "/nix/store/q51nrwn7hn9licpap3na9094gwnhczwb-nim.zfblast",
+          "sha256": "09g4awh7lnxy5bsmd2nvrj0vn7bmqvcnsh9mxwkcbiq8i7bbb503",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.16",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "1b4080df97f5b93b953952d99791611b7d2d4b75",
+          "date": "2020-07-20T09:30:36+07:00",
+          "path": "/nix/store/7hmrb2k75f8wcf2xbwr2xg5p5p4vn50w-nim.zfblast",
+          "sha256": "1n5c7brzbks8rq0pi1z45f1ardrwkpzvkjl6jadchqxlvjmbns1a",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.14",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "d9870ff3da36cfd9b18f531f67de1a8a14dd4c99",
+          "date": "2020-07-08T12:08:09+07:00",
+          "path": "/nix/store/h8xsahl72ysknp6rn49sbjgy2p1zd52x-nim.zfblast",
+          "sha256": "1dkvrsr40b4085ix0m7nflldg9x70gppnqhz0hsd3855pc8bl8n3",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.1.10",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfblast",
+          "rev": "5169bba3d1a2c1553febdbc4c9afa70fd35bc7cc",
+          "date": "2020-06-30T12:22:14+07:00",
+          "path": "/nix/store/7cy0l35psbhrdzvjjpnvj39ikpasbzqx-nim.zfblast",
+          "sha256": "10hwb5wdiq2zzb667w1pl8qn64byagrczpz4a1bxbqyphz0gqqbh",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.1.7",
         "value": {
           "url": "https://github.com/zendbit/nim.zfblast",
@@ -89,84 +167,6 @@
           "date": "2020-03-13T22:35:17+07:00",
           "sha256": "1mh3834n5f0cdlayj8qy74i0xlk6qv9wxplr7hkjkm9jzyci9ifw",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "0.1.19",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "f71008da3ea3690da9f5951e98645952673629f5",
-          "date": "2020-09-21T09:22:35+07:00",
-          "path": "/nix/store/5npzn1c19bwnzz8dyzad78hk24qv6s72-nim.zfblast",
-          "sha256": "1j1qj8nn14piypwaa3nwigj2yrvn0573fdcwb11rm7kpj3ks8bfr",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.17-old",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "ea7349c4d28e5b08e3f7afd1dd9910e41f0e8caf",
-          "date": "2020-07-25T13:11:30+07:00",
-          "path": "/nix/store/i152s9aihmzrg8yhf75dlh3c6gm7h1x4-nim.zfblast",
-          "sha256": "0h91j7hhv1fr7zqgrmmis99bs2r6lg2vcjs3gjmx7jk3pmcmz3wp",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.17",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "b6b81e39a7c325152a5a5e673fb2e1dbfacd7db6",
-          "date": "2020-07-25T07:35:53+07:00",
-          "path": "/nix/store/q51nrwn7hn9licpap3na9094gwnhczwb-nim.zfblast",
-          "sha256": "09g4awh7lnxy5bsmd2nvrj0vn7bmqvcnsh9mxwkcbiq8i7bbb503",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.16",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "1b4080df97f5b93b953952d99791611b7d2d4b75",
-          "date": "2020-07-20T09:30:36+07:00",
-          "path": "/nix/store/7hmrb2k75f8wcf2xbwr2xg5p5p4vn50w-nim.zfblast",
-          "sha256": "1n5c7brzbks8rq0pi1z45f1ardrwkpzvkjl6jadchqxlvjmbns1a",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.14",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "d9870ff3da36cfd9b18f531f67de1a8a14dd4c99",
-          "date": "2020-07-08T12:08:09+07:00",
-          "path": "/nix/store/h8xsahl72ysknp6rn49sbjgy2p1zd52x-nim.zfblast",
-          "sha256": "1dkvrsr40b4085ix0m7nflldg9x70gppnqhz0hsd3855pc8bl8n3",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.1.10",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfblast",
-          "rev": "5169bba3d1a2c1553febdbc4c9afa70fd35bc7cc",
-          "date": "2020-06-30T12:22:14+07:00",
-          "path": "/nix/store/7cy0l35psbhrdzvjjpnvj39ikpasbzqx-nim.zfblast",
-          "sha256": "10hwb5wdiq2zzb667w1pl8qn64byagrczpz4a1bxbqyphz0gqqbh",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/zfcore.json
+++ b/packages/zfcore.json
@@ -4,6 +4,84 @@
     "method": "git",
     "versions": [
       {
+        "name": "1.0.30",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "95853f7817c98e1759ec0a7e7c5b6a2bbe221081",
+          "date": "2020-10-21T08:45:22+07:00",
+          "path": "/nix/store/rvzn7b7dcwzb2ryq18pl82h958v58mpj-nim.zfcore",
+          "sha256": "1g9hk8qx7wga6vd26g42fjyw96xak7imia8w57s8c2is78q1w1gl",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.0.29",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "af614342a7b7e31a0baeae517f5de5ea5365a085",
+          "date": "2020-10-13T11:03:57+07:00",
+          "path": "/nix/store/83rarx1lv9kpwj15wc3131cmqy4srnvs-nim.zfcore",
+          "sha256": "0dw2jl9b0lf8l8dcrq4mlvznj6ykkg4d5ps21d7fqwpmckcdyw67",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.0.18",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "86f2a3f773051e7face5b646741aed061e390002",
+          "date": "2020-07-25T07:36:40+07:00",
+          "path": "/nix/store/q91gmyl0087mj2plzydvkg0wg4gnsh6n-nim.zfcore",
+          "sha256": "1y4vfm6lnhjnbj7hcb4bhi8wcs0n648sl50wrxd1c5vllyqa6g6v",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.0.16",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "3c0ac8583704064ca530ae3a710b4eb418965492",
+          "date": "2020-07-20T09:30:59+07:00",
+          "path": "/nix/store/d8jdzlgz9aclmp0n342c2f3bmqan9h6r-nim.zfcore",
+          "sha256": "07izfsjc39ap8bbz080y9x3zmpmajbiv0z3bmyjdbppa7rmc7yp0",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.0.15",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "b222deea4d19ec60a9b232db6620bb0a0f9c98e4",
+          "date": "2020-07-08T11:52:24+07:00",
+          "path": "/nix/store/yr4hdc93qcvglmf9sgyvnwg13534vi7f-nim.zfcore",
+          "sha256": "04qhlgcdkljzgmbrilcynl2vjlqnlgma17v3a7k40gfn53cw9mn0",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "1.0.11",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfcore",
+          "rev": "186a5e32fb1da608fd9e464f738382e6aeda584e",
+          "date": "2020-07-01T16:27:54+07:00",
+          "path": "/nix/store/r786575wpg05mcazw2rbl0z1462aidcx-nim.zfcore",
+          "sha256": "0adn2hvvwgjjjz2qxdn1qka4vbxgr07zhhwv5dyarq81rz6vsy9k",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "1.0.8-1",
         "value": {
           "url": "https://github.com/zendbit/nim.zfcore",
@@ -82,19 +160,6 @@
         }
       },
       {
-        "name": "1.0.30",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "95853f7817c98e1759ec0a7e7c5b6a2bbe221081",
-          "date": "2020-10-21T08:45:22+07:00",
-          "path": "/nix/store/rvzn7b7dcwzb2ryq18pl82h958v58mpj-nim.zfcore",
-          "sha256": "1g9hk8qx7wga6vd26g42fjyw96xak7imia8w57s8c2is78q1w1gl",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "1.0.3",
         "value": {
           "url": "https://github.com/zendbit/nim.zfcore",
@@ -108,19 +173,6 @@
         }
       },
       {
-        "name": "1.0.29",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "af614342a7b7e31a0baeae517f5de5ea5365a085",
-          "date": "2020-10-13T11:03:57+07:00",
-          "path": "/nix/store/83rarx1lv9kpwj15wc3131cmqy4srnvs-nim.zfcore",
-          "sha256": "0dw2jl9b0lf8l8dcrq4mlvznj6ykkg4d5ps21d7fqwpmckcdyw67",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "1.0.2",
         "value": {
           "url": "https://github.com/zendbit/nim.zfcore",
@@ -128,58 +180,6 @@
           "date": "2020-03-13T22:22:24+07:00",
           "sha256": "08waiky5pi5651hzk30s55gqmdpcgz9snkfk52pi6gycw8wfs9d1",
           "fetchSubmodules": false
-        }
-      },
-      {
-        "name": "1.0.18",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "86f2a3f773051e7face5b646741aed061e390002",
-          "date": "2020-07-25T07:36:40+07:00",
-          "path": "/nix/store/q91gmyl0087mj2plzydvkg0wg4gnsh6n-nim.zfcore",
-          "sha256": "1y4vfm6lnhjnbj7hcb4bhi8wcs0n648sl50wrxd1c5vllyqa6g6v",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.0.16",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "3c0ac8583704064ca530ae3a710b4eb418965492",
-          "date": "2020-07-20T09:30:59+07:00",
-          "path": "/nix/store/d8jdzlgz9aclmp0n342c2f3bmqan9h6r-nim.zfcore",
-          "sha256": "07izfsjc39ap8bbz080y9x3zmpmajbiv0z3bmyjdbppa7rmc7yp0",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.0.15",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "b222deea4d19ec60a9b232db6620bb0a0f9c98e4",
-          "date": "2020-07-08T11:52:24+07:00",
-          "path": "/nix/store/yr4hdc93qcvglmf9sgyvnwg13534vi7f-nim.zfcore",
-          "sha256": "04qhlgcdkljzgmbrilcynl2vjlqnlgma17v3a7k40gfn53cw9mn0",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "1.0.11",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfcore",
-          "rev": "186a5e32fb1da608fd9e464f738382e6aeda584e",
-          "date": "2020-07-01T16:27:54+07:00",
-          "path": "/nix/store/r786575wpg05mcazw2rbl0z1462aidcx-nim.zfcore",
-          "sha256": "0adn2hvvwgjjjz2qxdn1qka4vbxgr07zhhwv5dyarq81rz6vsy9k",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
         }
       },
       {

--- a/packages/zfplugs.json
+++ b/packages/zfplugs.json
@@ -4,45 +4,6 @@
     "method": "git",
     "versions": [
       {
-        "name": "0.0.6",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfplugs",
-          "rev": "9e011f1a98576acd071f492ea5c3f8b182343866",
-          "date": "2020-07-25T07:36:53+07:00",
-          "path": "/nix/store/9m4ns30j9bf9b5d28j2k2nfz51ii96li-nim.zfplugs",
-          "sha256": "1zzk9lmzs0k5w2b9qj6ykw673q0v0im5k3qxmsv0m2bgzaq825ag",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.0.5",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfplugs",
-          "rev": "f2e904864460d7e1695a37a6ea5a66c275e1e60f",
-          "date": "2020-07-20T09:30:48+07:00",
-          "path": "/nix/store/2z48myfpf343pb3h28rh75pzwl02ccsh-nim.zfplugs",
-          "sha256": "1f9w1sazjf6kr7wsc56648kjl5070yvnabc2azsv9wn2qmcn1mzk",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.0.3",
-        "value": {
-          "url": "https://github.com/zendbit/nim.zfplugs",
-          "rev": "61752b63ad16835e2074cc209de5d2b52a94f302",
-          "date": "2020-07-08T05:03:09+07:00",
-          "path": "/nix/store/gnighk01il1mbznzv49cyky7nhk1n279-nim.zfplugs",
-          "sha256": "04cr13hs7lnnsgp1fw4gilcz7ns9y2933bdlar7qg35qdffvji21",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
         "name": "0.0.23",
         "value": {
           "url": "https://github.com/zendbit/nim.zfplugs",
@@ -102,6 +63,45 @@
           "date": "2020-10-16T22:09:00+07:00",
           "path": "/nix/store/42yvdpr1wnkhjq8y2c5gnimi3sqqss1c-nim.zfplugs",
           "sha256": "003nx9f8sac6yrm2jgf8ys5d64x3q3fvjclz4rs2hcqg2qnkpvsd",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.0.6",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfplugs",
+          "rev": "9e011f1a98576acd071f492ea5c3f8b182343866",
+          "date": "2020-07-25T07:36:53+07:00",
+          "path": "/nix/store/9m4ns30j9bf9b5d28j2k2nfz51ii96li-nim.zfplugs",
+          "sha256": "1zzk9lmzs0k5w2b9qj6ykw673q0v0im5k3qxmsv0m2bgzaq825ag",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.0.5",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfplugs",
+          "rev": "f2e904864460d7e1695a37a6ea5a66c275e1e60f",
+          "date": "2020-07-20T09:30:48+07:00",
+          "path": "/nix/store/2z48myfpf343pb3h28rh75pzwl02ccsh-nim.zfplugs",
+          "sha256": "1f9w1sazjf6kr7wsc56648kjl5070yvnabc2azsv9wn2qmcn1mzk",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.0.3",
+        "value": {
+          "url": "https://github.com/zendbit/nim.zfplugs",
+          "rev": "61752b63ad16835e2074cc209de5d2b52a94f302",
+          "date": "2020-07-08T05:03:09+07:00",
+          "path": "/nix/store/gnighk01il1mbznzv49cyky7nhk1n279-nim.zfplugs",
+          "sha256": "04cr13hs7lnnsgp1fw4gilcz7ns9y2933bdlar7qg35qdffvji21",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/packages/zippy.json
+++ b/packages/zippy.json
@@ -4,6 +4,58 @@
     "method": "git",
     "versions": [
       {
+        "name": "0.3.13",
+        "value": {
+          "url": "https://github.com/guzba/zippy",
+          "rev": "4b92ef59ff6f23b6eb793cb972c536761106ac43",
+          "date": "2020-11-30T21:36:04-06:00",
+          "path": "/nix/store/b6hy59bjdc5jbj19q2ywfgzm9j8z9ifx-zippy",
+          "sha256": "05kl18yhw2m5y0jnkrm7ay2d3jmcsl2g88yfxps6p8qv5phc06qf",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.12",
+        "value": {
+          "url": "https://github.com/guzba/zippy",
+          "rev": "d113110a09aa4eb221e8f858536ca4b8bad3ba7f",
+          "date": "2020-11-28T21:24:27-06:00",
+          "path": "/nix/store/z5rjsj7p965d16xypycnxf6xl8hm4myh-zippy",
+          "sha256": "0w36w22f5bmwrdf8vk8yakh93a2rw4lkai7na8ibwl70q4bzqxgi",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.11",
+        "value": {
+          "url": "https://github.com/guzba/zippy",
+          "rev": "a310230eeca390bfd0f0bc07e056e579d4c6f567",
+          "date": "2020-11-26T17:13:56-06:00",
+          "path": "/nix/store/rv6kqfqj07g6gqg1kwarpp830zq08g1v-zippy",
+          "sha256": "0i4v4vsjmdk9n7axzb9984swa5vlfdddzx635ag498779zv0cg29",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
+        "name": "0.3.10",
+        "value": {
+          "url": "https://github.com/guzba/zippy",
+          "rev": "0f8a1d151065fafa008ab4aea8a2eb88a2a3b4fa",
+          "date": "2020-11-22T15:35:15-06:00",
+          "path": "/nix/store/bcwv05sp8c3jm4fvc4vjyrlhkqkx9m6w-zippy",
+          "sha256": "1lg7fbs50y2sn339s4bjvv4gg52zvfyfwryy8na764ad212px0rq",
+          "fetchSubmodules": false,
+          "deepClone": false,
+          "leaveDotGit": false
+        }
+      },
+      {
         "name": "0.3.9",
         "value": {
           "url": "https://github.com/guzba/zippy",
@@ -102,58 +154,6 @@
           "date": "2020-11-12T20:22:20-06:00",
           "path": "/nix/store/mgbwcmm5xw5ck0g1s216biplzfndgswi-zippy",
           "sha256": "0mylplsdyrkr34j979zbki6bzr3yz3qqr25pdaxkhak1b3f6zpar",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.13",
-        "value": {
-          "url": "https://github.com/guzba/zippy",
-          "rev": "4b92ef59ff6f23b6eb793cb972c536761106ac43",
-          "date": "2020-11-30T21:36:04-06:00",
-          "path": "/nix/store/b6hy59bjdc5jbj19q2ywfgzm9j8z9ifx-zippy",
-          "sha256": "05kl18yhw2m5y0jnkrm7ay2d3jmcsl2g88yfxps6p8qv5phc06qf",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.12",
-        "value": {
-          "url": "https://github.com/guzba/zippy",
-          "rev": "d113110a09aa4eb221e8f858536ca4b8bad3ba7f",
-          "date": "2020-11-28T21:24:27-06:00",
-          "path": "/nix/store/z5rjsj7p965d16xypycnxf6xl8hm4myh-zippy",
-          "sha256": "0w36w22f5bmwrdf8vk8yakh93a2rw4lkai7na8ibwl70q4bzqxgi",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.11",
-        "value": {
-          "url": "https://github.com/guzba/zippy",
-          "rev": "a310230eeca390bfd0f0bc07e056e579d4c6f567",
-          "date": "2020-11-26T17:13:56-06:00",
-          "path": "/nix/store/rv6kqfqj07g6gqg1kwarpp830zq08g1v-zippy",
-          "sha256": "0i4v4vsjmdk9n7axzb9984swa5vlfdddzx635ag498779zv0cg29",
-          "fetchSubmodules": false,
-          "deepClone": false,
-          "leaveDotGit": false
-        }
-      },
-      {
-        "name": "0.3.10",
-        "value": {
-          "url": "https://github.com/guzba/zippy",
-          "rev": "0f8a1d151065fafa008ab4aea8a2eb88a2a3b4fa",
-          "date": "2020-11-22T15:35:15-06:00",
-          "path": "/nix/store/bcwv05sp8c3jm4fvc4vjyrlhkqkx9m6w-zippy",
-          "sha256": "1lg7fbs50y2sn339s4bjvv4gg52zvfyfwryy8na764ad212px0rq",
           "fetchSubmodules": false,
           "deepClone": false,
           "leaveDotGit": false

--- a/src/nix_from_nimble.nim
+++ b/src/nix_from_nimble.nim
@@ -83,7 +83,13 @@ proc sourcesList(pkg: Package; prev: JsonNode): JsonNode =
       , "value": prefetchVersion(pkg)
       })
   proc cmpVer(x, y: JsonNode): int =
-    cmp(x["name"].str, y["name"].str)
+    let
+      xn = x["name"].str
+      yn = y["name"].str
+    if xn == "HEAD" and yn == "HEAD": return 0
+    elif xn == "HEAD": return 1
+    elif yn == "HEAD": return -1
+    cmp(newVersion(xn), newVersion(yn))
   sort(versionList.elems, cmpVer, SortOrder.Descending)
   result["versions"] = versionList
 


### PR DESCRIPTION

Previously, versions were sorted as strings, resulting in 0.9 > 0.10,
and bad versions being chosen as "newest" in packages/*.json. Fix this
to use semantic versioning comparisons.

